### PR TITLE
Expose filter changeItem

### DIFF
--- a/vue/components/ui/filter-platforme/filter-platforme.vue
+++ b/vue/components/ui/filter-platforme/filter-platforme.vue
@@ -180,6 +180,13 @@ export const FilterPlatforme = {
         updateQuery(options) {
             const { sort, reverse, filter } = options;
             this.$router.replace({ query: { ...this.$route.query, sort, reverse, filter } });
+        },
+        changeItem(index, item) {
+            if (item) {
+                this.items.$set(index, item);
+            } else {
+                this.items.splice(index, 1);
+            }
         }
     }
 };


### PR DESCRIPTION
`filter-platforme` manages the pagination of items based on a given filter. This is problematic when we want to update a single, such as when deleting an item or changing its state.

Exposing a method allows users to apply changes without having to refresh the whole listing or losing the visual feedback.