### PR TITLE
Move table style to ripe-components-vue

### DIFF
--- a/vue/components/ui/table-platforme/table-platforme.vue
+++ b/vue/components/ui/table-platforme/table-platforme.vue
@@ -91,22 +91,18 @@ table ::v-deep td > * {
     vertical-align: middle;
 }
 
-table ::v-deep td.image img {
-    height: auto;
-    max-height: 100%;
-    max-width: 100%;
-    width: auto;
-}
-
-table ::v-deep td > * {
-    vertical-align: middle;
-}
-
 table ::v-deep td a {
     border: none;
     display: inline-block;
     height: 20px;
     padding: 0px 0px 0px 0px;
+}
+
+table ::v-deep td.image img {
+    height: auto;
+    max-height: 100%;
+    max-width: 100%;
+    width: auto;
 }
 
 table ::v-deep td.icons .icon {

--- a/vue/components/ui/table-platforme/table-platforme.vue
+++ b/vue/components/ui/table-platforme/table-platforme.vue
@@ -98,6 +98,28 @@ table ::v-deep td.image img {
     width: auto;
 }
 
+table ::v-deep td > * {
+    vertical-align: middle;
+}
+
+table ::v-deep td a {
+    border: none;
+    display: inline-block;
+    height: 20px;
+    padding: 0px 0px 0px 0px;
+}
+
+table ::v-deep td.icons .icon {
+    height: 20px;
+    margin-right: 4px;
+    opacity: 0.6;
+    transition: opacity 0.125s ease-in-out;
+}
+
+table ::v-deep td.icons .icon:hover {
+    opacity: 1;
+}
+
 .column {
     transition: color 0.1s ease-in;
 }


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue |  |
| Decisions |  It was decided to move table style item's aliment from ripe-sputnik-ui to ripe-components-vue. This also fixes bad aligment.  |
| Animated GIF |  See below |

#### Before Presets:
<img width="1364" alt="Captura de ecrã 2019-11-11, às 16 58 51" src="https://user-images.githubusercontent.com/24736423/68606677-d2722680-04a6-11ea-8bd6-9f7eccb09f7b.png">

#### After Presets:
![Screenshot_2019-11-11 Presets - RIPE Sputnik](https://user-images.githubusercontent.com/24736423/68606658-cb4b1880-04a6-11ea-922a-81393b60c79c.png)


#### Before Jobs:
![imagem](https://user-images.githubusercontent.com/24736423/68853072-0c267580-06d1-11ea-9962-2a988d1a128f.png)

#### After Jobs:
<img width="1342" alt="imagem" src="https://user-images.githubusercontent.com/24736423/68852985-e305e500-06d0-11ea-84c2-98c29763f328.png">