### PR TITLE
Fix desktop's footer anchor style

### DIFF
--- a/vue/components/ui/footer-platforme/footer-platforme.vue
+++ b/vue/components/ui/footer-platforme/footer-platforme.vue
@@ -39,6 +39,11 @@
     padding-bottom: 20px;
 }
 
+a {
+    color: #4078c0;
+    text-decoration: none;
+}
+
 ul {
     display: inline-block;
     list-style: none;


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | - |
| Decisions | Fix anchor style of footer in accordance to pulse's footer.  |
| Animated GIF | Below  |

### Before 
<img width="1308" alt="imagem" src="https://user-images.githubusercontent.com/24736423/69259909-ead4f600-0bb6-11ea-89fc-9943c4e54221.png">

### After 
<img width="1308" alt="imagem" src="https://user-images.githubusercontent.com/24736423/69260177-6171f380-0bb7-11ea-8178-9ee5dd84e6b1.png">

