### PR TITLE
Fix URL loader usage

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,7 +25,10 @@ config.plugins.push(new webpack.BannerPlugin(banner));
 config.module.rules = config.module.rules.filter(rule => rule.loader !== "file-loader");
 config.module.rules.push({
     test: /\.(png|jpg|gif|svg|ico)$/,
-    loader: "url-loader"
+    loader: "url-loader",
+    options: {
+        esModule: false
+    }
 });
 
 module.exports = config;


### PR DESCRIPTION
As @3rdvision found out, it seems that the upgrade of `url-loader` to `3.0.0` [needs tuning](https://github.com/vuejs/vue-loader/issues/1612#issuecomment-559366730) to work with `vue-loader`.