### PR TITLE
Add missing modal-container z-index

### DIFF
--- a/vue/components/ui/header-platforme/header-platforme.vue
+++ b/vue/components/ui/header-platforme/header-platforme.vue
@@ -95,7 +95,7 @@
     position: fixed;
     top: 0px;
     width: 100%;
-    z-index: 30;
+    z-index: 40;
 }
 
 .app.first .header-platforme {

--- a/vue/components/ui/modal-platforme/modal-platforme.vue
+++ b/vue/components/ui/modal-platforme/modal-platforme.vue
@@ -86,6 +86,7 @@
     padding: 20px 26px 20px 26px;
     position: relative;
     width: 460px;
+    z-index: 20;
 }
 
 body.tablet .modal > .modal-container,

--- a/vue/components/ui/side-platforme/side-platforme.vue
+++ b/vue/components/ui/side-platforme/side-platforme.vue
@@ -31,7 +31,7 @@
     transition: left 0.25s cubic-bezier(0.645, 0.045, 0.355, 1),
         box-shadow 0.5s cubic-bezier(0.645, 0.045, 0.355, 1);
     width: 280px;
-    z-index: 20;
+    z-index: 30;
 }
 
 .side-platforme.visible {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Place modal container on top of it's own overlay. Also, keep same distance (10 indexes) between each component. |
| Decisions | - |
| Animated GIF | Below  |

### Before
<img width="635" alt="imagem" src="https://user-images.githubusercontent.com/24736423/70517875-3f71ee00-1b31-11ea-8aff-3b5a2edb97e0.png">

### After
<img width="635" alt="imagem" src="https://user-images.githubusercontent.com/24736423/70518162-c8892500-1b31-11ea-92ae-e9ae3ed9ebe7.png">



