### PR TITLE
Fix listing usage of slots

### DIFF
--- a/vue/components/ui/listing-platforme/listing-platforme.vue
+++ b/vue/components/ui/listing-platforme/listing-platforme.vue
@@ -32,6 +32,14 @@
                 ref="filter"
                 v-on:update:options="filterUpdated"
             >
+                <slot v-bind:name="slot" v-for="slot in Object.keys($slots)" v-bind:slot="slot" />
+                <template
+                    v-for="slot in Object.keys($scopedSlots)"
+                    v-bind:slot="slot"
+                    slot-scope="scope"
+                >
+                    <slot v-bind:name="slot" v-bind="scope" />
+                </template>
                 <template v-slot:item="{ item, index }">
                     <slot
                         name="item"
@@ -43,14 +51,6 @@
                 <template v-slot:empty>
                     <h1 v-if="notFoundText">{{ notFoundText }}</h1>
                     <h1 v-else>No {{ name }} found</h1>
-                </template>
-                <slot v-bind:name="slot" v-for="slot in Object.keys($slots)" v-bind:slot="slot" />
-                <template
-                    v-for="slot in Object.keys($scopedSlots)"
-                    v-bind:slot="slot"
-                    slot-scope="scope"
-                >
-                    <slot v-bind:name="slot" v-bind="scope" />
                 </template>
             </filter-platforme>
         </container-platforme>


### PR DESCRIPTION
Problem:
* Listing was receiving a slot named 'item'
* Expected: pass a **new** 'item' slot to Filtering
* Actual: pass the original 'item' slot
* Observed problem: adding filters by clicking on items on the `order-list` from Pulse didn't work