### PR TITLE
Fix text alignment on the tabs elements

### DIFF
--- a/vue/components/ui/tabs-platforme/tabs-platforme.vue
+++ b/vue/components/ui/tabs-platforme/tabs-platforme.vue
@@ -36,6 +36,7 @@
 
 .tabs > .header {
     border-bottom: 2px solid $lighter-grey;
+    text-align: left;
 }
 
 .tabs > .header > .tab-label {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | The current tab's buttons alignment are subjective to father styles alignments, like for example `body` tag with class `desktop` that forces the alignment to be set to `center`|
| Decisions | Force the correct behaviour by writing on the component it self the correct alignment |
| Animated GIF |   |
