### PR TITLE
Added details "globalEvents" prop

### DIFF
--- a/vue/components/ui/organisms/details/details.vue
+++ b/vue/components/ui/organisms/details/details.vue
@@ -469,6 +469,10 @@ export const Details = {
         getItems: {
             type: Function,
             required: true
+        },
+        globalEvents: {
+            type: Boolean,
+            default: true
         }
     },
     data: function() {
@@ -490,6 +494,8 @@ export const Details = {
             this.optionsVisible = !status;
         },
         async previousItem() {
+            if (!this.globalEvents) return;
+
             if (this.loading || !this.index) {
                 this.triggerAnimation("slide-left-fake");
                 return;
@@ -504,6 +510,8 @@ export const Details = {
                 : this.triggerAnimation("slide-left-fake");
         },
         async nextItem() {
+            if (!this.globalEvents) return;
+
             if (this.loading || this.index === undefined) {
                 this.triggerAnimation("slide-right-fake");
                 return;


### PR DESCRIPTION
Allows to ignore the keyboard events that currently changes the orders to the next one, or the previous one.