### PR TITLE
Fix undefined filter

### DIFF
--- a/vue/components/ui/organisms/listing/listing.vue
+++ b/vue/components/ui/organisms/listing/listing.vue
@@ -236,7 +236,7 @@ export const Listing = {
     data: function() {
         return {
             items: [],
-            filter: this.context.filter,
+            filter: this.context && this.context.filter ? this.context.filter : "",
             filterOptions: null,
             loading: false,
             visibleLightbox: null
@@ -247,7 +247,7 @@ export const Listing = {
             const base = `${key}=`;
             const tuple = `${key}=${value}`;
             if (this.filter && this.filter.search(base) !== -1) return;
-            this.filter = this.filter ? `${this.filter} and ${tuple}` : tuple;
+            this.filter += this.filter ? ` and ${tuple}` : tuple;
             this.showScrollTop = true;
             this.scrollTop = true;
         },

--- a/vue/components/ui/organisms/listing/listing.vue
+++ b/vue/components/ui/organisms/listing/listing.vue
@@ -236,7 +236,7 @@ export const Listing = {
     data: function() {
         return {
             items: [],
-            filter: this.context.filter,
+            filter: null,
             filterOptions: null,
             loading: false,
             visibleLightbox: null
@@ -247,7 +247,7 @@ export const Listing = {
             const base = `${key}=`;
             const tuple = `${key}=${value}`;
             if (this.filter && this.filter.search(base) !== -1) return;
-            this.filter += this.filter ? ` and ${tuple}` : tuple;
+            this.filter = this.filter ? `${this.filter} and ${tuple}` : tuple;
             this.showScrollTop = true;
             this.scrollTop = true;
         },

--- a/vue/components/ui/organisms/listing/listing.vue
+++ b/vue/components/ui/organisms/listing/listing.vue
@@ -236,7 +236,7 @@ export const Listing = {
     data: function() {
         return {
             items: [],
-            filter: null,
+            filter: this.context.filter,
             filterOptions: null,
             loading: false,
             visibleLightbox: null


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Below |
| Decisions | - |
| Animated GIF | ![5l7kPTJZpy](https://user-images.githubusercontent.com/24736423/71575631-942bd780-2ae5-11ea-8fad-d14a69f408e2.gif)  |

### Issue

When a user adds the first filter after landing on a page it will set the search input text field  to `"undefined<filter>"` instead of just `"<filter>"`.

This is because `this.context.filter` is undefined at the `created` vue instance moment therefore, as result, when `addFilter()` is called, `"undefined"` will concatenate to the value of `this.filter`.

Reproducible in any listing containing filters, for instance https://ripe-pulse-sbx.platforme.com/orders.

#### Steps to reproduce:

1 - Open https://ripe-pulse-sbx.platforme.com/orders;
2- Click a filter.

Undesired effect: `"undefined[...]"` will appear in the search field.