### PR TITLE
Fix input value type

### DIFF
--- a/vue/components/ui/atoms/input/input.vue
+++ b/vue/components/ui/atoms/input/input.vue
@@ -74,7 +74,7 @@ export const Input = {
             default: "thin"
         },
         value: {
-            type: String,
+            type: String | Number,
             default: ""
         },
         placeholder: {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Vue displays error in console if the prop `value` is a Number. This _small change_ spares the job of having to convert types when passing a numeric `value` to `input-ripe`. |
| Decisions | - |
| Animated GIF | - |
