### PR TITLE
Fixed "attachments" long names + Shows attachment name on hover

### DIFF
--- a/vue/components/ui/atoms/attachments/attachments.stories.js
+++ b/vue/components/ui/atoms/attachments/attachments.stories.js
@@ -33,6 +33,10 @@ storiesOf("Atoms", module)
                     {
                         name: "img-533122019",
                         path: "http://i.pravatar.cc"
+                    },
+                    {
+                        name: "long filename iuwafuehgsrdfig aoighh awipfojg oiegjsh img-533122019",
+                        path: "http://i.pravatar.cc"
                     }
                 ]
             },

--- a/vue/components/ui/atoms/attachments/attachments.vue
+++ b/vue/components/ui/atoms/attachments/attachments.vue
@@ -74,7 +74,10 @@
     border: none;
     display: inline-block;
     line-height: 44px;
+    overflow: hidden;
+    text-overflow: ellipsis;
     vertical-align: top;
+    white-space: nowrap;
     width: 100%;
 }
 </style>

--- a/vue/components/ui/atoms/attachments/attachments.vue
+++ b/vue/components/ui/atoms/attachments/attachments.vue
@@ -4,7 +4,7 @@
             {{ title }}
         </div>
         <div class="attachments-list" v-bind:style="listStyle">
-            <div class="attachment" v-for="(attachment, index) in attachments" v-bind:key="index">
+            <div class="attachment" v-bind:title="attachment.name" v-for="(attachment, index) in attachments" v-bind:key="index">
                 <link-ripe
                     v-bind:text="attachment.name"
                     v-bind:href="attachment.path"

--- a/vue/components/ui/atoms/attachments/attachments.vue
+++ b/vue/components/ui/atoms/attachments/attachments.vue
@@ -4,7 +4,12 @@
             {{ title }}
         </div>
         <div class="attachments-list" v-bind:style="listStyle">
-            <div class="attachment" v-bind:title="attachment.name" v-for="(attachment, index) in attachments" v-bind:key="index">
+            <div
+                class="attachment"
+                v-bind:title="attachment.name"
+                v-for="(attachment, index) in attachments"
+                v-bind:key="index"
+            >
                 <link-ripe
                     v-bind:text="attachment.name"
                     v-bind:href="attachment.path"


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue |  |
| Decisions | Attachments with long names are now displayed correctly and the user now sees the attachment name when hovering with the mouse on top of the attachment in the list of attachments.  |
| Animated GIF | **Before:** ![attachments_before](https://user-images.githubusercontent.com/22588915/71816644-2ea69080-307b-11ea-8805-762975da57a4.gif) **After:** ![attachments_after](https://user-images.githubusercontent.com/22588915/71816643-2ea69080-307b-11ea-8f5f-21cddf29a453.gif) |
