### PR TITLE
Add table extra-row slot

### DIFF
--- a/vue/components/ui/molecules/lightbox/lightbox.vue
+++ b/vue/components/ui/molecules/lightbox/lightbox.vue
@@ -7,7 +7,11 @@
             v-on:click="event => $emit('click', event)"
         />
         <transition name="fade">
-            <div class="lightbox-container" v-if="visible && (imageLightbox || image)" v-on:click="$emit('close')">
+            <div
+                class="lightbox-container"
+                v-if="visible && (imageLightbox || image)"
+                v-on:click="$emit('close')"
+            >
                 <div class="image-container">
                     <img v-bind:src="imageLightbox || image || ''" v-bind:alt="alt" />
                 </div>

--- a/vue/components/ui/molecules/table/table.custom.stories.js
+++ b/vue/components/ui/molecules/table/table.custom.stories.js
@@ -48,9 +48,14 @@ storiesOf("Molecules", module).add("Table Custom", () => ({
                     OS: {{ item.system }}
                 </td>
             </template>
-            <template v-slot:extra-row="{ item, index }">
+            <template v-slot:before-row="{ item, index }">
                 <tr v-bind:key="index">
-                    <td colspan="3">Extra row {{ index }}</td>
+                    <td colspan="3">Before row {{ index }}</td>
+                </tr>
+            </template>
+            <template v-slot:after-row="{ item, index }">
+                <tr v-bind:key="index">
+                    <td colspan="3">After row {{ index }}</td>
                 </tr>
             </template>
         </table-ripe>

--- a/vue/components/ui/molecules/table/table.custom.stories.js
+++ b/vue/components/ui/molecules/table/table.custom.stories.js
@@ -48,6 +48,11 @@ storiesOf("Molecules", module).add("Table Custom", () => ({
                     OS: {{ item.system }}
                 </td>
             </template>
+            <template v-slot:extra-row="{ item, index }">
+                <tr v-bind:key="index">
+                    <td colspan="3">Extra row {{ index }}</td>
+                </tr>
+            </template>
         </table-ripe>
     `
 }));

--- a/vue/components/ui/molecules/table/table.vue
+++ b/vue/components/ui/molecules/table/table.vue
@@ -266,7 +266,6 @@ export const Table = {
             }
 
             const items = [...this.items];
-            debugger;
             return this.sortMethod(items, this.sortData, this.reverseData);
         }
     },

--- a/vue/components/ui/molecules/table/table.vue
+++ b/vue/components/ui/molecules/table/table.vue
@@ -21,17 +21,20 @@
             </tr>
         </thead>
         <transition-group tag="tbody" v-bind:name="transition" class="table-body">
-            <tr v-for="(item, index) in sortedItems" v-bind:key="item.id">
-                <slot v-bind:item="item" v-bind:index="index">
-                    <td
-                        v-bind:class="column.value"
-                        v-for="column in columns"
-                        v-bind:key="column.value"
-                    >
-                        {{ item[column.value] }}
-                    </td>
-                </slot>
-            </tr>
+            <template v-for="(item, index) in sortedItems">
+                <tr v-bind:key="item.id" v-on:click="onClick(item, index)">
+                    <slot v-bind:item="item" v-bind:index="index">
+                        <td
+                            v-bind:class="column.value"
+                            v-for="column in columns"
+                            v-bind:key="column.value"
+                        >
+                            {{ item[column.value] }}
+                        </td>
+                    </slot>
+                </tr>
+                <slot name="extra-row" v-bind:item="item" v-bind:index="index" />
+            </template>
         </transition-group>
     </table>
 </template>
@@ -263,6 +266,7 @@ export const Table = {
             }
 
             const items = [...this.items];
+            debugger;
             return this.sortMethod(items, this.sortData, this.reverseData);
         }
     },
@@ -276,6 +280,9 @@ export const Table = {
             this.sortData = column;
             this.$emit("update:sort", this.sortData);
             this.$emit("update:reverse", this.reverseData);
+        },
+        onClick(item, index) {
+            this.$emit("click", item, index);
         }
     }
 };

--- a/vue/components/ui/molecules/table/table.vue
+++ b/vue/components/ui/molecules/table/table.vue
@@ -22,7 +22,7 @@
         </thead>
         <transition-group tag="tbody" v-bind:name="transition" class="table-body">
             <template v-for="(item, index) in sortedItems">
-                <tr v-bind:key="item.id" v-on:click="onClick(item, index)">
+                <tr v-bind:key="item.id">
                     <slot v-bind:item="item" v-bind:index="index">
                         <td
                             v-bind:class="column.value"
@@ -279,9 +279,6 @@ export const Table = {
             this.sortData = column;
             this.$emit("update:sort", this.sortData);
             this.$emit("update:reverse", this.reverseData);
-        },
-        onClick(item, index) {
-            this.$emit("click", item, index);
         }
     }
 };

--- a/vue/components/ui/molecules/table/table.vue
+++ b/vue/components/ui/molecules/table/table.vue
@@ -22,6 +22,7 @@
         </thead>
         <transition-group tag="tbody" v-bind:name="transition" class="table-body">
             <template v-for="(item, index) in sortedItems">
+                <slot name="before-row" v-bind:item="item" v-bind:index="index" />
                 <tr v-bind:key="item.id">
                     <slot v-bind:item="item" v-bind:index="index">
                         <td
@@ -33,7 +34,7 @@
                         </td>
                     </slot>
                 </tr>
-                <slot name="extra-row" v-bind:item="item" v-bind:index="index" />
+                <slot name="after-row" v-bind:item="item" v-bind:index="index" />
             </template>
         </transition-group>
     </table>


### PR DESCRIPTION
Use case: allowing extra info to appear below a row after a click (e.g.: order activity chat on RIPE Pulse).