### PR TITLE
Add ellipsis to input-ripe

### DIFF
--- a/vue/components/ui/atoms/input/input.stories.js
+++ b/vue/components/ui/atoms/input/input.stories.js
@@ -35,6 +35,9 @@ storiesOf("Atoms", module)
             disabled: {
                 default: boolean("Disabled", false)
             },
+            ellipsis: {
+                default: boolean("Ellipsis", true)
+            },
             header: {
                 default: text("Header", "Start Header")
             },

--- a/vue/components/ui/atoms/input/input.vue
+++ b/vue/components/ui/atoms/input/input.vue
@@ -31,9 +31,12 @@
     outline: none;
     padding-left: 12px;
     padding-right: 12px;
-    text-overflow: ellipsis;
     transition: width 0.2s ease, border-color 0.2s ease, background-color 0.2s ease;
     width: 100%;
+}
+
+.input.ellipsis {
+    text-overflow: ellipsis;
 }
 
 .input.dark {
@@ -90,6 +93,10 @@ export const Input = {
             type: Boolean,
             default: false
         },
+        ellipsis: {
+            type: Boolean,
+            default: true
+        },
         width: {
             type: Number,
             default: null
@@ -134,6 +141,7 @@ export const Input = {
             const base = {};
             if (this.variant) base[this.variant] = true;
             if (this.border) base[`border-${this.border}`] = true;
+            if (this.ellipsis) base.ellipsis = true;
             return base;
         }
     }

--- a/vue/components/ui/atoms/input/input.vue
+++ b/vue/components/ui/atoms/input/input.vue
@@ -31,6 +31,7 @@
     outline: none;
     padding-left: 12px;
     padding-right: 12px;
+    text-overflow: ellipsis;
     transition: width 0.2s ease, border-color 0.2s ease, background-color 0.2s ease;
     width: 100%;
 }


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | - |
| Decisions | As suggested in a PR's comment https://github.com/ripe-tech/ripe-components-vue/pull/168#discussion_r365787877, `text-overflow: ellipsis` should be default in `input-ripe`. |
| Animated GIF | <img width="434" alt="imagem" src="https://user-images.githubusercontent.com/24736423/72258338-b3f2ed80-3605-11ea-802e-81f65f710063.png"> |
