### PR TITLE
Changed Details item prop required to false

### DIFF
--- a/vue/components/ui/organisms/details/details.vue
+++ b/vue/components/ui/organisms/details/details.vue
@@ -491,7 +491,7 @@ export const Details = {
         },
         item: {
             type: Object,
-            required: true
+            required: false
         },
         index: {
             type: Number,

--- a/vue/components/ui/organisms/details/details.vue
+++ b/vue/components/ui/organisms/details/details.vue
@@ -490,8 +490,7 @@ export const Details = {
             required: true
         },
         item: {
-            type: Object,
-            required: false
+            type: Object
         },
         index: {
             type: Number,


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Props from component details required the item to exist from the start. But this creates an error in the majority of cases where we have a parent still requesting the item itself. |
| Decisions |  Remove the required from props so that no error appear. <br> It was  tested in the pulse project -> order show component by forcing the data request to always return null. No bugs where found in the UI or console logs. |
