### PR TITLE
Fix input width

### DIFF
--- a/vue/components/ui/atoms/input/input.vue
+++ b/vue/components/ui/atoms/input/input.vue
@@ -28,6 +28,7 @@
     height: 34px;
     letter-spacing: 0.25px;
     line-height: 34px;
+    min-width: 0px;
     outline: none;
     padding-left: 12px;
     padding-right: 12px;

--- a/vue/components/ui/molecules/lightbox/lightbox.vue
+++ b/vue/components/ui/molecules/lightbox/lightbox.vue
@@ -13,7 +13,11 @@
                 v-on:click="$emit('close')"
             >
                 <div class="image-container">
-                    <image-ripe v-bind:src="imageLightbox || image || ''" v-bind:alt="alt" v-bind:fade="false" />
+                    <image-ripe
+                        v-bind:src="imageLightbox || image || ''"
+                        v-bind:alt="alt"
+                        v-bind:fade="false"
+                    />
                 </div>
             </div>
         </transition>


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | When we pass a width prop lower than 203 to `input-symbol`, it doesn't size as it should. This is because input has a default browser's `width` and flexbox's `min-width: auto`. This can be solved by overriding the behavior  with `min-width: 0px`.  Further details at: https://stackoverflow.com/a/42421490   |
| Decisions |   |
| Animated GIF | Below  |

### Before
`width = 100`
<img width="405" alt="imagem" src="https://user-images.githubusercontent.com/24736423/72727777-adbfbc80-3b83-11ea-90ea-d13234822674.png">


### After
`width = 100`
<img width="405" alt="imagem" src="https://user-images.githubusercontent.com/24736423/72727980-2fafe580-3b84-11ea-9807-262fa3cee850.png">


