### PR TITLE
Fix table item click index

### DIFF
--- a/vue/components/ui/molecules/table/table.vue
+++ b/vue/components/ui/molecules/table/table.vue
@@ -260,12 +260,15 @@ export const Table = {
         };
     },
     computed: {
+        itemsWithIndex() {
+            return this.items.map((item, index) => ({ _originalIndex: index, ...item }));
+        },
         sortedItems() {
             if (!this.sortData) {
                 return this.items;
             }
 
-            const items = [...this.items];
+            const items = [...this.itemsWithIndex];
             return this.sortMethod(items, this.sortData, this.reverseData);
         }
     },
@@ -280,8 +283,8 @@ export const Table = {
             this.$emit("update:sort", this.sortData);
             this.$emit("update:reverse", this.reverseData);
         },
-        onClick(item, index) {
-            this.$emit("click", item, index);
+        onClick(item) {
+            this.$emit("click", item, item._originalIndex);
         }
     }
 };

--- a/vue/components/ui/molecules/table/table.vue
+++ b/vue/components/ui/molecules/table/table.vue
@@ -265,7 +265,7 @@ export const Table = {
         },
         sortedItems() {
             if (!this.sortData) {
-                return this.items;
+                return this.itemsWithIndex;
             }
 
             const items = [...this.itemsWithIndex];

--- a/vue/components/ui/molecules/table/table.vue
+++ b/vue/components/ui/molecules/table/table.vue
@@ -23,7 +23,7 @@
         <transition-group tag="tbody" v-bind:name="transition" class="table-body">
             <template v-for="(item, index) in sortedItems">
                 <slot name="before-row" v-bind:item="item" v-bind:index="index" />
-                <tr v-bind:key="item.id" v-on:click="onClick(item)">
+                <tr v-bind:key="item.id" v-on:click="onClick(item, index)">
                     <slot v-bind:item="item" v-bind:index="index">
                         <td
                             v-bind:class="column.value"
@@ -283,8 +283,8 @@ export const Table = {
             this.$emit("update:sort", this.sortData);
             this.$emit("update:reverse", this.reverseData);
         },
-        onClick(item) {
-            this.$emit("click", item, item._originalIndex);
+        onClick(item, rowIndex) {
+            this.$emit("click", item, item._originalIndex, rowIndex);
         }
     }
 };

--- a/vue/components/ui/molecules/table/table.vue
+++ b/vue/components/ui/molecules/table/table.vue
@@ -283,8 +283,8 @@ export const Table = {
             this.$emit("update:sort", this.sortData);
             this.$emit("update:reverse", this.reverseData);
         },
-        onClick(item, rowIndex) {
-            this.$emit("click", item, item._originalIndex, rowIndex);
+        onClick(item, index) {
+            this.$emit("click", item, item._originalIndex, index);
         }
     }
 };

--- a/vue/components/ui/molecules/table/table.vue
+++ b/vue/components/ui/molecules/table/table.vue
@@ -23,7 +23,7 @@
         <transition-group tag="tbody" v-bind:name="transition" class="table-body">
             <template v-for="(item, index) in sortedItems">
                 <slot name="before-row" v-bind:item="item" v-bind:index="index" />
-                <tr v-bind:key="item.id" v-on:click="onClick(item, index)">
+                <tr v-bind:key="item.id" v-on:click="onClick(item)">
                     <slot v-bind:item="item" v-bind:index="index">
                         <td
                             v-bind:class="column.value"


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | When a table row is clicked, `table-ripe` emits a click event `$emit("click", item, index)`, and is expected that the payload of that event is the clicked item and the item's index position in the `items` passed as prop. Instead, it is emiting the position index in the table. This is a problem when the table has different a orientation than the original when sorted and/or reversed. With this fix `$emit("click", item, index)` will emit in the click event, the clicked item and the respective item's index. |
| Decisions |   |
| Animated GIF |   |
