### PR TITLE
Add to table mouseover and header height prop

### DIFF
--- a/vue/components/ui/molecules/table/table.vue
+++ b/vue/components/ui/molecules/table/table.vue
@@ -26,7 +26,7 @@
                 <tr
                     v-bind:key="item.id"
                     v-on:click="onClick(item, index)"
-                    v-on:mouseover="mouseOver(item, index)"
+                    v-on:mouseover="onMouseOver(item, index)"
                 >
                     <slot v-bind:item="item" v-bind:index="index">
                         <td
@@ -251,7 +251,7 @@ export const Table = {
         },
         headerHeight: {
             type: Number,
-            default: 36
+            default: null
         }
     },
     watch: {
@@ -295,7 +295,7 @@ export const Table = {
         onClick(item, index) {
             this.$emit("click", item, index);
         },
-        mouseOver(item, index) {
+        onMouseOver(item, index) {
             this.$emit("mouse:over", item, index);
         }
     }

--- a/vue/components/ui/molecules/table/table.vue
+++ b/vue/components/ui/molecules/table/table.vue
@@ -3,7 +3,7 @@
         <thead class="table-head">
             <tr>
                 <th
-                    v-bind:style="{ width: column.width }"
+                    v-bind:style="columnStyle(column)"
                     v-for="column in columns"
                     v-bind:key="column.value"
                 >
@@ -23,7 +23,11 @@
         <transition-group tag="tbody" v-bind:name="transition" class="table-body">
             <template v-for="(item, index) in sortedItems">
                 <slot name="before-row" v-bind:item="item" v-bind:index="index" />
-                <tr v-bind:key="item.id" v-on:click="onClick(item, index)">
+                <tr
+                    v-bind:key="item.id"
+                    v-on:click="onClick(item, index)"
+                    v-on:mouseover="mouseOver(item, index)"
+                >
                     <slot v-bind:item="item" v-bind:index="index">
                         <td
                             v-bind:class="column.value"
@@ -244,6 +248,10 @@ export const Table = {
         reverse: {
             type: Boolean,
             default: false
+        },
+        headerHeight: {
+            type: Number,
+            default: 36
         }
     },
     watch: {
@@ -275,6 +283,9 @@ export const Table = {
             const order = this.reverseData ? "ascending" : "descending";
             return this.sortData === column ? `active ${order}` : "";
         },
+        columnStyle(column) {
+            return { width: column.width, height: `${this.headerHeight}px` };
+        },
         sortColumn(column) {
             this.reverseData = this.sortData === column ? !this.reverseData : false;
             this.sortData = column;
@@ -283,6 +294,9 @@ export const Table = {
         },
         onClick(item, index) {
             this.$emit("click", item, index);
+        },
+        mouseOver(item, index) {
+            this.$emit("mouse:over", item, index);
         }
     }
 };


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | We need `mouseover` and a prop to set the height of the table header to be able to build the dynamic component |
| Decisions |  Pass those trough props and apply in the code |
| Animated GIF |   |
