### PR TITLE
Fix listing story header

### DIFF
--- a/vue/components/ui/organisms/listing/listing.stories.js
+++ b/vue/components/ui/organisms/listing/listing.stories.js
@@ -9,7 +9,7 @@ storiesOf("Organisms", module)
                 type: Object,
                 default: () => ({ filter: "" })
             },
-            columns: {
+            tableColumns: {
                 type: Array,
                 default: () => [
                     { value: "id", label: "ID", width: "100px" },
@@ -17,7 +17,7 @@ storiesOf("Organisms", module)
                     { value: "device", label: "Device" }
                 ]
             },
-            values: {
+            lineupFields: {
                 type: Array,
                 default: () => [
                     { value: "id", label: "ID", width: "100px" },
@@ -65,12 +65,12 @@ storiesOf("Organisms", module)
                 <global></global>
                 <listing
                     v-bind:context="context"
-                    v-bind:columns="columns"
+                    v-bind:table-columns="tableColumns"
                     v-bind:get-items="getItems"
                     v-bind:name="'devices'"
                     v-bind:use-query="false"
                     v-bind:filter-fields="filterFields"
-                    v-bind:values="values"
+                    v-bind:lineup-fields="lineupFields"
                 >
                     <template v-slot:icons>
                         <img v-bind:src="img" v-bind:style="imgStyle" />

--- a/vue/components/ui/organisms/listing/listing.stories.js
+++ b/vue/components/ui/organisms/listing/listing.stories.js
@@ -66,11 +66,11 @@ storiesOf("Organisms", module)
                 <listing
                     v-bind:context="context"
                     v-bind:table-columns="tableColumns"
+                    v-bind:lineup-fields="lineupFields"
                     v-bind:get-items="getItems"
                     v-bind:name="'devices'"
                     v-bind:use-query="false"
                     v-bind:filter-fields="filterFields"
-                    v-bind:lineup-fields="lineupFields"
                 >
                     <template v-slot:icons>
                         <img v-bind:src="img" v-bind:style="imgStyle" />


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Header wasn't showing in the listing story. Prop naming was outdated. |
| Decisions | Updated listing story with the new prop naming. |
| Animated GIF | -- |
