### PR TITLE
Fix input min width bug

### DIFF
--- a/vue/components/ui/atoms/input/input.stories.js
+++ b/vue/components/ui/atoms/input/input.stories.js
@@ -57,7 +57,7 @@ storiesOf("Atoms", module)
                 default: number("Width", null)
             },
             minWidth: {
-                default: number("Minimum Width", null)
+                default: number("Minimum width", null)
             },
             height: {
                 default: number("Height", null)

--- a/vue/components/ui/atoms/input/input.stories.js
+++ b/vue/components/ui/atoms/input/input.stories.js
@@ -56,6 +56,9 @@ storiesOf("Atoms", module)
             width: {
                 default: number("Width", null)
             },
+            minWidth: {
+                default: number("Minimum Width", null)
+            },
             height: {
                 default: number("Height", null)
             }
@@ -86,6 +89,7 @@ storiesOf("Atoms", module)
                         v-bind:placeholder="placeholder"
                         v-bind:disabled="disabled"
                         v-bind:width="width"
+                        v-bind:min-width="minWidth"
                         v-bind:height="height"></input-ripe>
                 </form-input>
                 <p>Text: {{ valueData }}</p>

--- a/vue/components/ui/atoms/input/input.vue
+++ b/vue/components/ui/atoms/input/input.vue
@@ -105,6 +105,10 @@ export const Input = {
             type: Number,
             default: null
         },
+        minWidth: {
+            type: Number,
+            default: null
+        },
         height: {
             type: Number,
             default: null
@@ -138,6 +142,7 @@ export const Input = {
             const base = {
                 width: this.width === null ? null : `${this.width}px`,
                 height: this.height === null ? null : `${this.height}px`,
+                "min-width": this.minWidth === null ? null : `${this.minWidth}px`,
                 "text-align": this.align
             };
             return base;

--- a/vue/components/ui/molecules/input-symbol/input-symbol.vue
+++ b/vue/components/ui/molecules/input-symbol/input-symbol.vue
@@ -7,6 +7,7 @@
             v-bind:placeholder="placeholder"
             v-bind:disabled="disabled"
             v-bind:height="height"
+            v-bind:min-width="0"
             v-bind:align="align"
             v-on:update:value="onInput"
             v-on:blur="onBlur"


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | When we pass a width prop lower than 203 to `input-symbol`, it doesn't size as it should. This is because input has a default browser's `width` and flexbox's `min-width: auto`. This can be solved by overriding the behavior  with `min-width: 0px`.  Further details at: https://stackoverflow.com/a/42421490   |
| Decisions |   |
| Animated GIF | Below  |

### Before
`width = 100`
<img width="405" alt="imagem" src="https://user-images.githubusercontent.com/24736423/72727777-adbfbc80-3b83-11ea-90ea-d13234822674.png">

**Note:** Border in blue doesn't display correctly and the width of the element is not 100px but 100 + 24px.

### After
`width = 100`
<img width="405" alt="imagem" src="https://user-images.githubusercontent.com/24736423/72727980-2fafe580-3b84-11ea-9807-262fa3cee850.png">


