### PR TITLE
Fix lineup story "value" into "field"

### DIFF
--- a/vue/components/ui/molecules/lineup/lineup.stories.js
+++ b/vue/components/ui/molecules/lineup/lineup.stories.js
@@ -57,7 +57,7 @@ storiesOf("Molecules", module)
                 <template v-slot:city-key>
                     Custom city title
                 </template>
-                <template v-slot:city-value>
+                <template v-slot:city-field>
                     Custom city value
                 </template>
                 <template v-slot:trousers-note>


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Lineup story using value instead of field |
| Decisions | Changed value to field |
| Animated GIF | -- |
