### PR TITLE
Fix scroll-button interference

### DIFF
--- a/vue/components/ui/organisms/listing/listing.vue
+++ b/vue/components/ui/organisms/listing/listing.vue
@@ -88,6 +88,7 @@
     transform: scale(0.75);
     transition: opacity 0.125s ease-in-out, transform 0.125s ease-in-out;
     width: 50px;
+    z-index: 1;
 }
 
 .scroll-button.show {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | When listing has `button-icons`, `scroll-icon` doesn't correctly overlap. Mouse click and hover effect don't work as expected. |
| Decisions |   |
| Animated GIF | Below |

### Before
![waw](https://user-images.githubusercontent.com/24736423/73446911-99cf4400-4355-11ea-8f92-6b93e2b79e85.gif)


### After
![waw2](https://user-images.githubusercontent.com/24736423/73446938-a5bb0600-4355-11ea-92c0-bc0cbd2ae5fb.gif)
