### PR TITLE
Fix checkbox changes

### DIFF
--- a/vue/components/ui/atoms/checkbox/checkbox.vue
+++ b/vue/components/ui/atoms/checkbox/checkbox.vue
@@ -178,7 +178,7 @@ export const Checkbox = {
             if (this.disabled) return;
 
             this.checkedData = !this.checkedData;
-            this.$emit("update:checked", this.checkedData, this.value, this.index);
+            this.$emit("update:checked", this.checkedData);
         },
         onSpace() {
             this.toggle();

--- a/vue/components/ui/molecules/checkbox-group/checkbox-group.vue
+++ b/vue/components/ui/molecules/checkbox-group/checkbox-group.vue
@@ -5,7 +5,7 @@
                 name="before-item"
                 v-bind:index="index"
                 v-bind:item="item"
-                v-bind:checked="item.value === value"
+                v-bind:checked="checkedData[item.value]"
             />
             <checkbox
                 v-bind:label="item.label || item.value"
@@ -18,7 +18,7 @@
                 name="after-item"
                 v-bind:index="index"
                 v-bind:item="item"
-                v-bind:checked="item.value === value"
+                v-bind:checked="checkedData[item.value]"
             />
         </div>
     </div>


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | `index` and `value` variables are no longer in use when emitting updates in the checkbox component: . Checkbox group also suffers from old variables such as `value` still in use.  |
| Decisions | - |
| Animated GIF | - |
