### PR TITLE
Fix checkbox active style

### DIFF
--- a/vue/components/ui/atoms/checkbox/checkbox.vue
+++ b/vue/components/ui/atoms/checkbox/checkbox.vue
@@ -48,11 +48,6 @@
     width: 4px;
 }
 
-.checkbox:not(.disabled):not(.error) > .checkbox-input:active > .checkbox-square {
-    border: 2px solid #f4f5f7;
-    padding: 3px 3px 3px 3px;
-}
-
 .checkbox.error > .checkbox-input > .checkbox-square {
     background-color: #f4f5f7;
     border: 2px solid $dark-red;
@@ -68,6 +63,10 @@
     background-color: $dark;
     border: 2px solid $dark;
     padding: 3px 3px 3px 3px;
+}
+
+.checkbox.checked.active > .checkbox-input > .checkbox-square {
+    background-color: #f4f5f7;
 }
 
 .checkbox.error.checked > .checkbox-input > .checkbox-square {
@@ -144,7 +143,8 @@ export const Checkbox = {
         classes() {
             const base = {
                 checked: this.checkedData,
-                disabled: this.disabled
+                disabled: this.disabled,
+                active: this.active
             };
 
             if (this.variant) base[this.variant] = true;


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | When the checkbox was checked and active, the background color was off. ![Feb-05-2020 12-45-49](https://user-images.githubusercontent.com/25725586/73843026-af40e400-4815-11ea-8154-b20b0e1467be.gif)|
| Decisions | Style for checked and active.  |
| Animated GIF | After fix: ![Feb-05-2020 12-46-07](https://user-images.githubusercontent.com/25725586/73843062-c8499500-4815-11ea-9812-9baeb7cb5884.gif) |
