### PR TITLE
Added prop to allow to hide the header buttons

### DIFF
--- a/vue/components/ui/organisms/details/details.stories.js
+++ b/vue/components/ui/organisms/details/details.stories.js
@@ -58,6 +58,10 @@ storiesOf("Organisms", module)
                     { label: "Item 2", event: "item_2" },
                     { label: "Item 3", event: "item_3" }
                 ]
+            },
+            hideHeaderButtons: {
+                type: Boolean,
+                default: boolean("Hide Header buttons", false)
             }
         },
         template: `
@@ -73,6 +77,7 @@ storiesOf("Organisms", module)
                 v-bind:context="{}"
                 v-bind:index="0"
                 v-bind:get-items="() => values"
+                v-bind:hide-header-buttons="hideHeaderButtons"
             >
                 <template v-slot:shirt>
                     <p>Custom entry</p>

--- a/vue/components/ui/organisms/details/details.stories.js
+++ b/vue/components/ui/organisms/details/details.stories.js
@@ -59,9 +59,9 @@ storiesOf("Organisms", module)
                     { label: "Item 3", event: "item_3" }
                 ]
             },
-            hideHeaderButtons: {
+            headerButtons: {
                 type: Boolean,
-                default: boolean("Hide Header buttons", false)
+                default: boolean("Header buttons", true)
             }
         },
         template: `
@@ -77,7 +77,7 @@ storiesOf("Organisms", module)
                 v-bind:context="{}"
                 v-bind:index="0"
                 v-bind:get-items="() => values"
-                v-bind:hide-header-buttons="hideHeaderButtons"
+                v-bind:header-buttons="headerButtons"
             >
                 <template v-slot:shirt>
                     <p>Custom entry</p>

--- a/vue/components/ui/organisms/details/details.stories.js
+++ b/vue/components/ui/organisms/details/details.stories.js
@@ -61,7 +61,7 @@ storiesOf("Organisms", module)
             },
             headerButtons: {
                 type: Boolean,
-                default: boolean("Header buttons", true)
+                default: boolean("Header Buttons", true)
             }
         },
         template: `

--- a/vue/components/ui/organisms/details/details.vue
+++ b/vue/components/ui/organisms/details/details.vue
@@ -68,7 +68,7 @@
         </container-ripe>
         <container-ripe class="details-container" v-else>
             <div class="container-header">
-                <div class="header-buttons">
+                <div class="header-buttons" v-if="!hideHeaderButtons">
                     <slot name="header-buttons">
                         <slot name="header-buttons-before" />
                         <div class="header-button">
@@ -530,6 +530,10 @@ export const Details = {
             default: true
         },
         safe: {
+            type: Boolean,
+            default: false
+        },
+        hideHeaderButtons: {
             type: Boolean,
             default: false
         }

--- a/vue/components/ui/organisms/details/details.vue
+++ b/vue/components/ui/organisms/details/details.vue
@@ -68,7 +68,7 @@
         </container-ripe>
         <container-ripe class="details-container" v-else>
             <div class="container-header">
-                <div class="header-buttons" v-if="!hideHeaderButtons">
+                <div class="header-buttons" v-if="headerButtons">
                     <slot name="header-buttons">
                         <slot name="header-buttons-before" />
                         <div class="header-button">
@@ -533,9 +533,9 @@ export const Details = {
             type: Boolean,
             default: false
         },
-        hideHeaderButtons: {
+        headerButtons: {
             type: Boolean,
-            default: false
+            default: true
         }
     },
     data: function() {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | - |
| Decisions | Header buttons can now be hidden by a prop |
| Animated GIF | ![details-ripe_hide_header_buttons_2](https://user-images.githubusercontent.com/22588915/74731718-7dca0e80-5240-11ea-9c6d-0ca721510eb2.gif) |