### PR TITLE
Fix default type of button-color

### DIFF
--- a/vue/components/ui/atoms/button-color/button-color.vue
+++ b/vue/components/ui/atoms/button-color/button-color.vue
@@ -309,7 +309,7 @@ export const ButtonColor = {
         },
         type: {
             type: String,
-            default: null
+            default: "button"
         },
         alignment: {
             type: String,


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | The default `type` attribute of the `button` in `button-color` component should be `button` and not `submit` which is the current default attribute value caused by `type` property being null (https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button). |
| Decisions |   |
| Animated GIF |   |
