### PR TITLE
Let click events propagate

### DIFF
--- a/vue/components/ui/atoms/dropdown/dropdown.vue
+++ b/vue/components/ui/atoms/dropdown/dropdown.vue
@@ -8,7 +8,7 @@
                     v-bind:class="_getItemClasses(item, index)"
                     v-for="(item, index) in items.filter(v => v !== null && v !== undefined)"
                     v-bind:key="item.value"
-                    v-on:click.stop="click(item)"
+                    v-on:click="click(item)"
                     v-on:mouseenter="onMouseenter(index)"
                     v-on:mouseleave="onMouseleave(index)"
                 >

--- a/vue/components/ui/molecules/button-dropdown/button-dropdown.vue
+++ b/vue/components/ui/molecules/button-dropdown/button-dropdown.vue
@@ -7,7 +7,7 @@
             </template>
             <span class="label">{{ label }} </span>
         </div>
-        <div class="button button-secondary" v-on:click.stop="onSecondaryClick">
+        <div class="button button-secondary" v-on:click="onSecondaryClick">
             <icon class="icon icon-front" v-bind:icon="secondaryIcon" v-bind:color="'#000000'" />
             <icon class="icon icon-back" v-bind:icon="secondaryIcon" v-bind:color="'#ffffff'" />
         </div>

--- a/vue/components/ui/molecules/select/select.vue
+++ b/vue/components/ui/molecules/select/select.vue
@@ -22,7 +22,6 @@
             <div
                 class="select-button"
                 tabindex="0"
-                ref="select-button"
                 v-on:click="onClickDropdownButton"
                 v-on:keydown.exact="() => onKey($event.key)"
                 v-on:keydown.esc.exact="onEscKey"

--- a/vue/components/ui/molecules/select/select.vue
+++ b/vue/components/ui/molecules/select/select.vue
@@ -22,6 +22,7 @@
             <div
                 class="select-button"
                 tabindex="0"
+                ref="select-button"
                 v-on:click="onClickDropdownButton"
                 v-on:keydown.exact="() => onKey($event.key)"
                 v-on:keydown.esc.exact="onEscKey"
@@ -33,7 +34,6 @@
                 v-on:keydown.alt.up="onAltUpKey"
                 v-on:keydown.enter.exact="onEnterKey"
                 v-on:keydown.space.exact="onSpaceKey"
-                v-on:click.stop.prevent
             >
                 {{ buttonText }}
             </div>
@@ -281,7 +281,10 @@ export const Select = {
                 dropdown.scrollTop = indexEnd - dropdown.clientHeight;
             }
         },
-        onGlobalClick() {
+        onGlobalClick(event) {
+            const selectButton = this.$refs["select-button"];
+            // The click was in select's own button, ignore
+            if (selectButton && selectButton === event.target) return;
             this.closeDropdown();
         },
         onClickDropdownButton() {

--- a/vue/components/ui/molecules/select/select.vue
+++ b/vue/components/ui/molecules/select/select.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="select" v-bind:class="classes">
+    <div class="select" v-bind:class="classes" ref="select">
         <global-events v-on:click="onGlobalClick" />
         <select
             class="dropdown-select"
@@ -282,9 +282,8 @@ export const Select = {
             }
         },
         onGlobalClick(event) {
-            const selectButton = this.$refs["select-button"];
-            // The click was in this select's own button, ignore
-            if (selectButton && selectButton === event.target) return;
+            // The click was in this select, ignore
+            if (this.$refs.select.contains(event.target)) return;
             this.closeDropdown();
         },
         onClickDropdownButton() {

--- a/vue/components/ui/molecules/select/select.vue
+++ b/vue/components/ui/molecules/select/select.vue
@@ -283,7 +283,7 @@ export const Select = {
         },
         onGlobalClick(event) {
             const selectButton = this.$refs["select-button"];
-            // The click was in select's own button, ignore
+            // The click was in this select's own button, ignore
             if (selectButton && selectButton === event.target) return;
             this.closeDropdown();
         },


### PR DESCRIPTION
Fixes the issue that resulted in opening a dropdown not closing the one previously open.