### PR TITLE
Fix input type

### DIFF
--- a/vue/components/ui/molecules/input-currency/input-currency.vue
+++ b/vue/components/ui/molecules/input-currency/input-currency.vue
@@ -5,7 +5,6 @@
         v-bind:variant="variant"
         v-bind:border="border"
         v-bind:placeholder="placeholder"
-        v-bind:type="'number'"
         v-bind:autofocus="autofocus"
         v-bind:disabled="disabled"
         v-bind:width="width"


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | When component `input-currency` exists inside a `<form>` HTML5 will validate the number and reject any float number. Float numbers would need `step="any"` which would need `lang="en"` to use dots instead of commas. It might be better to just change the type to text. |
| Decisions | - |
| Animated GIF | <img width="277" alt="imagem" src="https://user-images.githubusercontent.com/24736423/75536716-a0f97880-5a0d-11ea-8c41-eb165f23c981.png"> |
