### PR TITLE
Fix bad change

### DIFF
--- a/vue/components/ui/atoms/button-icon/button-icon.vue
+++ b/vue/components/ui/atoms/button-icon/button-icon.vue
@@ -229,7 +229,7 @@ export const ButtonIcon = {
                 width: `${this.size / 3}px`,
                 height: `${this.size / 3}px`,
                 "border-width": `${this.size / 15}px`,
-                "margin-top": `${this.size / 15}px`
+                margin: `${this.size / 15}px 0px 0px 0px`
             };
         },
         style() {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Bad change in https://github.com/ripe-tech/ripe-components-vue/pull/298/commits/2b5bec21365a87673a37869328e66f4ad16617a2 |
| Dependencies | -- |
| Decisions | The `margin` applied in the `loaderStyle` was to fix the problem of the "ball-clip-rotate" animation not being centered giving the visual artifact that can be seen below |
| Animated GIF | **Before bad change fix:**<br>![Components-button-icon_fix_bad_change](https://user-images.githubusercontent.com/22588915/81557339-b5e67680-9383-11ea-95aa-3c7bb690e378.gif)<br><br> **After bad change fix:**<br>![Components-button-icon_fix_bad_change_fix](https://user-images.githubusercontent.com/22588915/81557326-b0892c00-9383-11ea-8ac2-b2786a12ab7f.gif) |
