### PR TITLE
Manually control "button-icon" "active" state

### DIFF
--- a/vue/components/ui/atoms/button-icon/button-icon.stories.js
+++ b/vue/components/ui/atoms/button-icon/button-icon.stories.js
@@ -51,6 +51,9 @@ storiesOf("Atoms", module)
             },
             loading: {
                 default: boolean("Loading", false)
+            },
+            active: {
+                default: boolean("Active", false)
             }
         },
         template: `
@@ -64,6 +67,7 @@ storiesOf("Atoms", module)
                 v-bind:disabled="disabled"
                 v-bind:selectable="selectable"
                 v-bind:loading="loading"
+                v-bind:active="active"
             />
         `
     }));

--- a/vue/components/ui/atoms/button-icon/button-icon.vue
+++ b/vue/components/ui/atoms/button-icon/button-icon.vue
@@ -54,6 +54,7 @@
     background-color: $lighter-grey;
 }
 
+.button-icon.active:not(.disabled):not(.unselectable),
 .button-icon:active:not(.disabled):not(.unselectable) {
     background-color: $light-grey;
 }
@@ -66,6 +67,7 @@
     background-color: #dedede;
 }
 
+.button-icon.button-icon-grey.active:not(.disabled):not(.unselectable),
 .button-icon.button-icon-grey:active:not(.disabled):not(.unselectable) {
     background-color: #cecece;
 }
@@ -78,6 +80,7 @@
     background-color: $lighter-grey;
 }
 
+.button-icon.button-icon-white.active:not(.disabled):not(.unselectable),
 .button-icon.button-icon-white:active:not(.disabled):not(.unselectable) {
     background-color: $light-grey;
 }
@@ -90,7 +93,7 @@
     background-color: #41566f;
 }
 
-.button-icon.button-icon-black:active:not(.disabled):not(.unselectable) {
+.button-icon.button-icon-black.active:not(.disabled):not(.unselectable) .button-icon.button-icon-black:active:not(.disabled):not(.unselectable) {
     background-color: $dark;
 }
 
@@ -214,6 +217,10 @@ export const ButtonIcon = {
         loading: {
             type: Boolean,
             default: false
+        },
+        active: {
+            type: Boolean,
+            default: false
         }
     },
     computed: {
@@ -262,7 +269,8 @@ export const ButtonIcon = {
             const base = {
                 disabled: this.disabled,
                 unselectable: !this.selectable,
-                "button-icon-text": Boolean(this.text)
+                "button-icon-text": Boolean(this.text),
+                active: this.active
             };
             if (this.color) base["button-icon-" + this.color] = this.color;
             return base;

--- a/vue/components/ui/atoms/button-icon/button-icon.vue
+++ b/vue/components/ui/atoms/button-icon/button-icon.vue
@@ -93,7 +93,8 @@
     background-color: #41566f;
 }
 
-.button-icon.button-icon-black.active:not(.disabled):not(.unselectable) .button-icon.button-icon-black:active:not(.disabled):not(.unselectable) {
+.button-icon.button-icon-black.active:not(.disabled):not(.unselectable),
+.button-icon.button-icon-black:active:not(.disabled):not(.unselectable) {
     background-color: $dark;
 }
 


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | -- |
| Dependencies | -- |
| Decisions | Can now manually control the `button-icon` `active` state, useful in cases like a dropdown, where we want to set the `button-icon` as active as long as the dropdown is open |
| Animated GIF |  ![Components-button-icon_active_via_prop](https://user-images.githubusercontent.com/22588915/81567577-69576700-9394-11ea-8f43-36c9cbbe7be2.gif)<br>**E.g. Useful when using with dropdowns:**<br>![May-11-2020 14-31-32](https://user-images.githubusercontent.com/22588915/81567818-c7844a00-9394-11ea-91de-9df2222bd17c.gif) |
