### PR TITLE
Extra icons support

### DIFF
--- a/vue/assets/icons/extra/options.svg
+++ b/vue/assets/icons/extra/options.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" aria-labelledby="ellypsisVerticalIconTitle ellypsisVerticalIconDesc" stroke="#000" stroke-width="3" stroke-linecap="square" fill="none" color="#000"><path d="M11 12a1 1 0 112 0 1 1 0 01-2 0zm0-6a1 1 0 112 0 1 1 0 01-2 0zm0 12a1 1 0 112 0 1 1 0 01-2 0z"/></svg>

--- a/vue/components/ui/atoms/icon/icon.vue
+++ b/vue/components/ui/atoms/icon/icon.vue
@@ -83,7 +83,11 @@ export const Icon = {
             try {
                 let resource = this.icon;
                 if (typeof this.icon === "string") {
-                    resource = require(`!!raw-loader!./../../../../assets/icons/${this.icon}.svg`);
+                    try {
+                        resource = require(`!!raw-loader!./../../../../assets/icons/extra/${this.icon}.svg`);
+                    } catch (error) {
+                        resource = require(`!!raw-loader!./../../../../assets/icons/${this.icon}.svg`);
+                    }
                 }
                 return resource.default;
             } catch (error) {

--- a/vue/components/ui/atoms/icon/icon.vue
+++ b/vue/components/ui/atoms/icon/icon.vue
@@ -84,9 +84,9 @@ export const Icon = {
                 let resource = this.icon;
                 if (typeof this.icon === "string") {
                     try {
-                        resource = require(`!!raw-loader!./../../../../assets/icons/extra/${this.icon}.svg`);
-                    } catch (error) {
                         resource = require(`!!raw-loader!./../../../../assets/icons/${this.icon}.svg`);
+                    } catch (err) {
+                        resource = require(`!!raw-loader!./../../../../assets/icons/extra/${this.icon}.svg`);
                     }
                 }
                 return resource.default;


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Needed "options" icon to be in `icons` component to be able to better refactor `details-ripe` |
| Dependencies | -- |
| Decisions | • Support the addition of new icons in the "extra" folder <br>• Added "options" icon (obtained from `details-ripe` asset folder |
| Animated GIF | ![Components-icon_extra_options](https://user-images.githubusercontent.com/22588915/81587758-65850e00-93af-11ea-96bd-4d238ac4f124.gif)<br><br>**Its the same used by `details-ripe`:**<br>![May-11-2020 14-31-32](https://user-images.githubusercontent.com/22588915/81587908-9e24e780-93af-11ea-821f-63a096649f19.gif) |
