### PR TITLE
#305 - Fix mobile apps menu bug

### DIFF
--- a/vue/components/ui/organisms/header/header.vue
+++ b/vue/components/ui/organisms/header/header.vue
@@ -282,7 +282,7 @@ body.mobile .header-ripe > .header-bar > .header-container > .header-apps ::v-de
     width: 300px;
 }
 
-.header-ripe > .header-bar > .header-container > .header-apps ::v-deep .dropdown {
+.header-ripe > .header-bar > .header-container > .header-apps ::v-deep .dropdown-container > .dropdown {
     background-color: $white;
     box-shadow: 0 10px 20px 0 rgba(0, 0, 0, 0.07);
     box-sizing: border-box;
@@ -296,11 +296,11 @@ body.mobile .header-ripe > .header-bar > .header-container > .header-apps ::v-de
     text-align: left;
 }
 
-body.mobile .header-ripe > .header-bar > .header-container > .header-apps ::v-deep .dropdown {
+body.mobile .header-ripe > .header-bar > .header-container > .header-apps ::v-deep .dropdown-container > .dropdown {
     margin: 0px 0px 0px 0px;
 }
 
-.header-ripe > .header-bar > .header-container > .header-apps ::v-deep .dropdown li {
+.header-ripe > .header-bar > .header-container > .header-apps ::v-deep .dropdown-container > .dropdown li {
     border-radius: 8px 8px 8px 8px;
     display: inline-block;
     font-size: 12px;
@@ -309,11 +309,11 @@ body.mobile .header-ripe > .header-bar > .header-container > .header-apps ::v-de
     text-align: center;
 }
 
-body.mobile .header-ripe > .header-bar > .header-container > .header-apps ::v-deep .dropdown li {
-    width: 138px;
+body.mobile .header-ripe > .header-bar > .header-container > .header-apps ::v-deep .dropdown-container > .dropdown li {
+    width: 139px;
 }
 
-.header-ripe > .header-bar > .header-container > .header-apps ::v-deep .dropdown li a {
+.header-ripe > .header-bar > .header-container > .header-apps ::v-deep .dropdown-container > .dropdown li a {
     border-bottom: none;
     color: $blacker;
     display: inline-block;
@@ -322,12 +322,12 @@ body.mobile .header-ripe > .header-bar > .header-container > .header-apps ::v-de
     width: 100px;
 }
 
-.header-ripe > .header-bar > .header-container > .header-apps ::v-deep .dropdown li img {
+.header-ripe > .header-bar > .header-container > .header-apps ::v-deep .dropdown-container > .dropdown li img {
     height: 40px;
     width: 40px;
 }
 
-.header-ripe > .header-bar > .header-container > .header-apps ::v-deep .dropdown li p {
+.header-ripe > .header-bar > .header-container > .header-apps ::v-deep .dropdown-container > .dropdown li p {
     font-weight: 600;
     margin: 6px 0px 0px 0px;
 }

--- a/vue/components/ui/organisms/header/header.vue
+++ b/vue/components/ui/organisms/header/header.vue
@@ -276,6 +276,12 @@
     background-color: rgba(60, 64, 67, 0.2);
 }
 
+body.mobile .header-ripe > .header-bar > .header-container > .header-apps ::v-deep .dropdown-container {
+    position: fixed;
+    right: 0%;
+    width: 300px;
+}
+
 .header-ripe > .header-bar > .header-container > .header-apps ::v-deep .dropdown {
     background-color: $white;
     box-shadow: 0 10px 20px 0 rgba(0, 0, 0, 0.07);
@@ -290,6 +296,10 @@
     text-align: left;
 }
 
+body.mobile .header-ripe > .header-bar > .header-container > .header-apps ::v-deep .dropdown {
+    margin: 0px 0px 0px 0px;
+}
+
 .header-ripe > .header-bar > .header-container > .header-apps ::v-deep .dropdown li {
     border-radius: 8px 8px 8px 8px;
     display: inline-block;
@@ -297,6 +307,10 @@
     margin: 0px 0px 0px 0px;
     padding: 0px 0px 0px 0px;
     text-align: center;
+}
+
+body.mobile .header-ripe > .header-bar > .header-container > .header-apps ::v-deep .dropdown li {
+    width: 138px;
 }
 
 .header-ripe > .header-bar > .header-container > .header-apps ::v-deep .dropdown li a {

--- a/vue/components/ui/organisms/header/header.vue
+++ b/vue/components/ui/organisms/header/header.vue
@@ -276,17 +276,18 @@
     background-color: rgba(60, 64, 67, 0.2);
 }
 
-.header-ripe > .header-bar > .header-container > .header-apps ::v-deep .dropdown-container {
+.header-ripe > .header-bar > .header-container > .header-apps > .dropdown-container {
+    max-width: 358px;
     position: fixed;
     right: 0%;
-    width: 358px;
+    width: auto;
 }
 
-body.mobile .header-ripe > .header-bar > .header-container > .header-apps ::v-deep .dropdown-container {
-    width: 300px;
+body.mobile .header-ripe > .header-bar > .header-container > .header-apps > .dropdown-container {
+    max-width: 300px;
 }
 
-.header-ripe > .header-bar > .header-container > .header-apps ::v-deep .dropdown-container > .dropdown {
+.header-ripe > .header-bar > .header-container > .header-apps > .dropdown-container ::v-deep .dropdown {
     background-color: $white;
     box-shadow: 0 10px 20px 0 rgba(0, 0, 0, 0.07);
     box-sizing: border-box;
@@ -295,16 +296,15 @@ body.mobile .header-ripe > .header-bar > .header-container > .header-apps ::v-de
     line-height: normal;
     margin-right: -6px;
     margin-top: -4px;
-    max-width: 358px;
     padding: 10px;
     text-align: left;
 }
 
-body.mobile .header-ripe > .header-bar > .header-container > .header-apps ::v-deep .dropdown-container > .dropdown {
+body.mobile .header-ripe > .header-bar > .header-container > .header-apps > .dropdown-container ::v-deep .dropdown {
     margin: 0px 0px 0px 0px;
 }
 
-.header-ripe > .header-bar > .header-container > .header-apps ::v-deep .dropdown-container > .dropdown > .dropdown-item {
+.header-ripe > .header-bar > .header-container > .header-apps > .dropdown-container ::v-deep .dropdown > .dropdown-item {
     border-radius: 8px 8px 8px 8px;
     display: inline-block;
     font-size: 12px;
@@ -313,11 +313,11 @@ body.mobile .header-ripe > .header-bar > .header-container > .header-apps ::v-de
     text-align: center;
 }
 
-body.mobile .header-ripe > .header-bar > .header-container > .header-apps ::v-deep .dropdown-container > .dropdown > .dropdown-item {
+body.mobile .header-ripe > .header-bar > .header-container > .header-apps > .dropdown-container ::v-deep .dropdown > .dropdown-item {
     width: 139px;
 }
 
-.header-ripe > .header-bar > .header-container > .header-apps ::v-deep .dropdown-container > .dropdown > .dropdown-item a {
+.header-ripe > .header-bar > .header-container > .header-apps > .dropdown-container ::v-deep .dropdown > .dropdown-item a {
     border-bottom: none;
     color: $blacker;
     display: inline-block;
@@ -326,12 +326,12 @@ body.mobile .header-ripe > .header-bar > .header-container > .header-apps ::v-de
     width: 100px;
 }
 
-.header-ripe > .header-bar > .header-container > .header-apps ::v-deep .dropdown-container > .dropdown > .dropdown-item img {
+.header-ripe > .header-bar > .header-container > .header-apps > .dropdown-container ::v-deep .dropdown > .dropdown-item img {
     height: 40px;
     width: 40px;
 }
 
-.header-ripe > .header-bar > .header-container > .header-apps ::v-deep .dropdown-container > .dropdown > .dropdown-item p {
+.header-ripe > .header-bar > .header-container > .header-apps .dropdown-container ::v-deep .dropdown > .dropdown-item p {
     font-weight: 600;
     margin: 6px 0px 0px 0px;
 }

--- a/vue/components/ui/organisms/header/header.vue
+++ b/vue/components/ui/organisms/header/header.vue
@@ -279,6 +279,10 @@
 .header-ripe > .header-bar > .header-container > .header-apps ::v-deep .dropdown-container {
     position: fixed;
     right: 0%;
+    width: 358px;
+}
+
+body.mobile .header-ripe > .header-bar > .header-container > .header-apps ::v-deep .dropdown-container {
     width: 300px;
 }
 

--- a/vue/components/ui/organisms/header/header.vue
+++ b/vue/components/ui/organisms/header/header.vue
@@ -300,7 +300,7 @@ body.mobile .header-ripe > .header-bar > .header-container > .header-apps ::v-de
     margin: 0px 0px 0px 0px;
 }
 
-.header-ripe > .header-bar > .header-container > .header-apps ::v-deep .dropdown-container > .dropdown li {
+.header-ripe > .header-bar > .header-container > .header-apps ::v-deep .dropdown-container > .dropdown > .dropdown-item {
     border-radius: 8px 8px 8px 8px;
     display: inline-block;
     font-size: 12px;
@@ -309,11 +309,11 @@ body.mobile .header-ripe > .header-bar > .header-container > .header-apps ::v-de
     text-align: center;
 }
 
-body.mobile .header-ripe > .header-bar > .header-container > .header-apps ::v-deep .dropdown-container > .dropdown li {
+body.mobile .header-ripe > .header-bar > .header-container > .header-apps ::v-deep .dropdown-container > .dropdown > .dropdown-item {
     width: 139px;
 }
 
-.header-ripe > .header-bar > .header-container > .header-apps ::v-deep .dropdown-container > .dropdown li a {
+.header-ripe > .header-bar > .header-container > .header-apps ::v-deep .dropdown-container > .dropdown > .dropdown-item a {
     border-bottom: none;
     color: $blacker;
     display: inline-block;
@@ -322,12 +322,12 @@ body.mobile .header-ripe > .header-bar > .header-container > .header-apps ::v-de
     width: 100px;
 }
 
-.header-ripe > .header-bar > .header-container > .header-apps ::v-deep .dropdown-container > .dropdown li img {
+.header-ripe > .header-bar > .header-container > .header-apps ::v-deep .dropdown-container > .dropdown > .dropdown-item img {
     height: 40px;
     width: 40px;
 }
 
-.header-ripe > .header-bar > .header-container > .header-apps ::v-deep .dropdown-container > .dropdown li p {
+.header-ripe > .header-bar > .header-container > .header-apps ::v-deep .dropdown-container > .dropdown > .dropdown-item p {
     font-weight: 600;
     margin: 6px 0px 0px 0px;
 }

--- a/vue/components/ui/organisms/header/header.vue
+++ b/vue/components/ui/organisms/header/header.vue
@@ -276,7 +276,7 @@
     background-color: rgba(60, 64, 67, 0.2);
 }
 
-body.mobile .header-ripe > .header-bar > .header-container > .header-apps ::v-deep .dropdown-container {
+.header-ripe > .header-bar > .header-container > .header-apps ::v-deep .dropdown-container {
     position: fixed;
     right: 0%;
     width: 300px;


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-components-vue/issues/305 |
| Dependencies | - |
| Decisions | So to fix this bug we had two ideas, first was to implement a full width menu as you can see on the first picture and the second was a smaller menu with 300px of width aligned to the right with a small variant of two or there items per row, we verify that google use's the same type of component and after some discussion internally we concluded that this might be the best option to put in motion, so we end up creating the component with the two items variant has it seemed more clean. <br>Assets:<br><img width="427" alt="Screenshot 2020-05-14 at 12 33 20" src="https://user-images.githubusercontent.com/13239857/81962814-34554980-960c-11ea-879d-c1bb45e6f7ad.png"><br><img width="527" alt="Screenshot 2020-05-14 at 12 33 56" src="https://user-images.githubusercontent.com/13239857/81962824-39b29400-960c-11ea-8a1e-d403aae2ede1.png"><br><img width="466" alt="Screenshot 2020-05-14 at 12 34 32" src="https://user-images.githubusercontent.com/13239857/81962844-3fa87500-960c-11ea-8734-fd91f64a7295.png">|
| Animated GIF | with bug: <br>![May-14-2020 17-48-13](https://user-images.githubusercontent.com/13239857/81962100-2a7f1680-960b-11ea-80f0-f6e17e849951.gif) <br>Fixed<br>![May-14-2020 17-48-03](https://user-images.githubusercontent.com/13239857/81962128-35d24200-960b-11ea-9f58-2b5a27d336d1.gif)|
