### PR TITLE
Hide all header-buttons-before and header-buttons-after in tablet and mobile

### DIFF
--- a/vue/components/ui/organisms/details/details.vue
+++ b/vue/components/ui/organisms/details/details.vue
@@ -10,10 +10,7 @@
             <template v-slot:header>
                 <div class="header-buttons">
                     <slot name="header-buttons">
-                        <slot
-                            name="header-buttons-before"
-                            v-if="isDesktopWidth()"
-                        />
+                        <slot name="header-buttons-before" v-if="isDesktopWidth()" />
                         <div class="header-button">
                             <span class="button-stats" v-on:click="onStatsClick">
                                 <img src="~./assets/stats.svg" />
@@ -61,7 +58,7 @@
                             />
                             <p>Status</p>
                         </div>
-                        <slot name="header-buttons-after" />
+                        <slot name="header-buttons-after" v-if="isDesktopWidth()" />
                     </slot>
                 </div>
                 <title-ripe v-if="invalid">
@@ -81,10 +78,7 @@
             <template v-slot:header>
                 <div class="header-buttons" v-if="headerButtons">
                     <slot name="header-buttons">
-                        <slot
-                            name="header-buttons-before"
-                            v-if="isDesktopWidth()"
-                        />
+                        <slot name="header-buttons-before" v-if="isDesktopWidth()" />
                         <div class="header-button">
                             <span class="button-stats" v-on:click="onStatsClick">
                                 <img src="~./assets/stats.svg" />
@@ -132,7 +126,7 @@
                             />
                             <p>Status</p>
                         </div>
-                        <slot name="header-buttons-after" />
+                        <slot name="header-buttons-after" v-if="isDesktopWidth()" />
                     </slot>
                 </div>
                 <slot name="title" v-if="isLoaded">

--- a/vue/components/ui/organisms/details/details.vue
+++ b/vue/components/ui/organisms/details/details.vue
@@ -10,7 +10,10 @@
             <template v-slot:header>
                 <div class="header-buttons">
                     <slot name="header-buttons">
-                        <slot name="header-buttons-before" />
+                        <slot
+                            name="header-buttons-before"
+                            v-if="isDesktopWidth()"
+                        />
                         <div class="header-button">
                             <span class="button-stats" v-on:click="onStatsClick">
                                 <img src="~./assets/stats.svg" />
@@ -78,7 +81,10 @@
             <template v-slot:header>
                 <div class="header-buttons" v-if="headerButtons">
                     <slot name="header-buttons">
-                        <slot name="header-buttons-before" />
+                        <slot
+                            name="header-buttons-before"
+                            v-if="isDesktopWidth()"
+                        />
                         <div class="header-button">
                             <span class="button-stats" v-on:click="onStatsClick">
                                 <img src="~./assets/stats.svg" />
@@ -456,8 +462,11 @@ body.mobile .container-ripe .details-column .label-value {
 </style>
 
 <script>
+import { partMixin } from "../../../../mixins/part";
+
 export const Details = {
     name: "details-ripe",
+    mixins: [partMixin],
     props: {
         name: {
             type: String,


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Fix header-button to copy the link not hiding when in mobile and tablet mode |
| Dependencies | - |
| Decisions | Hide all header-buttons-before if not in desktop as suggested in https://github.com/ripe-tech/ripe-pulse/pull/126#discussion_r430610318. |
| Animated GIF | Below |

### Before
<img width="462" alt="image" src="https://user-images.githubusercontent.com/24736423/82925185-4e304e00-9f75-11ea-971f-ef41e1be1742.png">

### After
<img width="462" alt="image" src="https://user-images.githubusercontent.com/24736423/82925279-6738ff00-9f75-11ea-8a6e-9283e2333464.png">
