### PR TITLE
Change specific items in the options dropdown of the details component

### DIFF
--- a/vue/components/ui/organisms/details/details.stories.js
+++ b/vue/components/ui/organisms/details/details.stories.js
@@ -54,9 +54,10 @@ storiesOf("Organisms", module)
             optionsItems: {
                 type: Array,
                 default: () => [
-                    { label: "Item 1", event: "item_1" },
-                    { label: "Item 2", event: "item_2" },
-                    { label: "Item 3", event: "item_3" }
+                    { label: "Item 1", value: "item_1", event: "item_1" },
+                    { label: "Item 2", value: "item_2", event: "item_2" },
+                    { label: "Item 3", value: "item_3", separator: true, event: "item_3" },
+                    { label: "Item 4", value: "item_4", event: "item_4" }
                 ]
             },
             headerButtons: {
@@ -84,6 +85,9 @@ storiesOf("Organisms", module)
                 </template>
                 <template v-slot:label-city>
                     <p>Custom label</p>
+                </template>
+                <template v-slot:options-item_4>
+                    <div>Custom item</div>
                 </template>
             </details-ripe>
         `

--- a/vue/components/ui/organisms/details/details.vue
+++ b/vue/components/ui/organisms/details/details.vue
@@ -55,7 +55,20 @@
                                 v-bind:visible.sync="optionsVisible"
                                 v-bind:owners="$refs['button-options-loading']"
                                 v-on:item-clicked="onOptionsItemClick"
-                            />
+                            >
+                                <slot
+                                    v-bind:name="slot"
+                                    v-for="slot in optionsSlots"
+                                    v-bind:slot="slot.replace('options-', '')"
+                                />
+                                <template
+                                    v-for="slot in optionsScopedSlots"
+                                    v-bind:slot="slot.replace('options-', '')"
+                                    slot-scope="scope"
+                                >
+                                    <slot v-bind:name="slot" v-bind="scope" />
+                                </template>
+                            </dropdown>
                             <p>Status</p>
                         </div>
                         <slot name="header-buttons-after" v-if="isDesktopWidth()" />
@@ -123,7 +136,20 @@
                                 v-bind:visible.sync="optionsVisible"
                                 v-bind:owners="$refs['button-options']"
                                 v-on:item-clicked="onOptionsItemClick"
-                            />
+                            >
+                                <slot
+                                    v-bind:name="slot"
+                                    v-for="slot in optionsSlots"
+                                    v-bind:slot="slot.replace('options-', '')"
+                                />
+                                <template
+                                    v-for="slot in optionsScopedSlots"
+                                    v-bind:slot="slot.replace('options-', '')"
+                                    slot-scope="scope"
+                                >
+                                    <slot v-bind:name="slot" v-bind="scope" />
+                                </template>
+                            </dropdown>
                             <p>Status</p>
                         </div>
                         <slot name="header-buttons-after" v-if="isDesktopWidth()" />
@@ -546,6 +572,12 @@ export const Details = {
         },
         hasIndex() {
             return this.index !== null && this.index !== undefined;
+        },
+        optionsSlots() {
+            return Object.keys(this.$slots).filter(slot => slot.startsWith("options-"));
+        },
+        optionsScopedSlots() {
+            return Object.keys(this.$scopedSlots).filter(slot => slot.startsWith("options-"));
         }
     },
     methods: {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | -- |
| Dependencies | -- |
| Decisions | • Added the ability to use `slots` named with the prefix "options-" to change a specific `item` in the options `dropdown` of the `details` component <br>• Improved storybook with an example of the implemented feature |
| Animated GIF | ![Components-Details_options_dropdown_item_slot_support](https://user-images.githubusercontent.com/22588915/84788475-11d99600-afe7-11ea-98b4-bd3b07288066.gif) |
