### PR TITLE
Skip handleClick when disabled

### DIFF
--- a/vue/components/ui/atoms/button-color/button-color.vue
+++ b/vue/components/ui/atoms/button-color/button-color.vue
@@ -342,6 +342,7 @@ export const ButtonColor = {
     },
     methods: {
         handleClick(event) {
+            if (this.disabled) return;
             if (this.href) {
                 if (this.target) window.open(this.href, this.target);
                 else document.location = this.href;


### PR DESCRIPTION
| - | - |
| --- | --- |
| Decisions | On top of having `pointer-events: none`, skips the click event handler when the button is disabled. Port from https://github.com/ripe-tech/ripe-commons-pluginus/pull/131/ |
