### PR TITLE
Add support for dropdown icons

### DIFF
--- a/vue/components/ui/atoms/dropdown/dropdown.stories.js
+++ b/vue/components/ui/atoms/dropdown/dropdown.stories.js
@@ -51,7 +51,8 @@ storiesOf("Atoms", module)
                     },
                     {
                         value: "text_3",
-                        label: "Text 3"
+                        label: "Icon with text",
+                        icon: "clipboard"
                     },
                     {
                         value: "text_platforme",

--- a/vue/components/ui/atoms/dropdown/dropdown.vue
+++ b/vue/components/ui/atoms/dropdown/dropdown.vue
@@ -23,17 +23,19 @@
                             v-bind:highlighted="highlightedData[index]"
                             v-bind:selected="selectedData[index]"
                         >
-                            <router-link v-bind:to="item.link" v-if="item.link">
+                            <icon v-bind:width="18" v-bind:height="18" v-bind:icon="item.icon" v-if="item.icon" />
+                            <router-link class="label" v-bind:to="item.link" v-if="item.link">
                                 {{ item.label || item.value }}
                             </router-link>
                             <a
+                                class="label"
                                 v-bind:href="item.href"
                                 v-bind:target="item.target || '_self'"
                                 v-else-if="item.href"
                             >
                                 {{ item.label || item.value }}
                             </a>
-                            <span v-else>{{ item.label || item.value }}</span>
+                            <span class="label" v-else>{{ item.label || item.value }}</span>
                         </slot>
                     </slot>
                 </li>
@@ -94,6 +96,7 @@
 }
 
 .dropdown-container .dropdown > .dropdown-item {
+    display: flex;
     background-color: $white;
     cursor: pointer;
     line-height: 18px;
@@ -101,6 +104,20 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+}
+
+.dropdown-container .dropdown > .dropdown-item > .icon {
+    box-sizing: content-box;
+    height: 18px;
+    width: 18px;
+    padding-right: 0px;
+}
+
+.dropdown-container .dropdown > .dropdown-item > .label {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    width: auto;
 }
 
 .dropdown-container .dropdown > .dropdown-item:hover,
@@ -116,7 +133,6 @@
 
 .dropdown-container .dropdown > .dropdown-item > * {
     box-sizing: border-box;
-    display: inline-block;
     padding: 8px 14px 8px 14px;
     width: 100%;
 }

--- a/vue/components/ui/atoms/dropdown/dropdown.vue
+++ b/vue/components/ui/atoms/dropdown/dropdown.vue
@@ -23,7 +23,12 @@
                             v-bind:highlighted="highlightedData[index]"
                             v-bind:selected="selectedData[index]"
                         >
-                            <icon v-bind:width="18" v-bind:height="18" v-bind:icon="item.icon" v-if="item.icon" />
+                            <icon
+                                v-bind:width="18"
+                                v-bind:height="18"
+                                v-bind:icon="item.icon"
+                                v-if="item.icon"
+                            />
                             <router-link class="label" v-bind:to="item.link" v-if="item.link">
                                 {{ item.label || item.value }}
                             </router-link>
@@ -96,9 +101,9 @@
 }
 
 .dropdown-container .dropdown > .dropdown-item {
-    display: flex;
     background-color: $white;
     cursor: pointer;
+    display: flex;
     line-height: 18px;
     margin: 0px 0px 0px 0px;
     overflow: hidden;
@@ -109,8 +114,8 @@
 .dropdown-container .dropdown > .dropdown-item > .icon {
     box-sizing: content-box;
     height: 18px;
-    width: 18px;
     padding-right: 0px;
+    width: 18px;
 }
 
 .dropdown-container .dropdown > .dropdown-item > .label {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Decisions | There seem to be no regressions in other Pulse dropdowns (header). |
| Animated GIF | ![image](https://user-images.githubusercontent.com/3048875/86273270-e3071680-bbc7-11ea-897a-67c0f334a220.png) ![image](https://user-images.githubusercontent.com/3048875/86273292-ea2e2480-bbc7-11ea-8b82-2cfdd86e2b9c.png) |
