### PR TITLE
Set dropdown managed to default to false

### DIFF
--- a/vue/components/ui/atoms/dropdown/dropdown.vue
+++ b/vue/components/ui/atoms/dropdown/dropdown.vue
@@ -160,7 +160,7 @@ export const Dropdown = {
         },
         managed: {
             type: Boolean,
-            default: true
+            default: false
         },
         globalEvents: {
             type: Boolean,


### PR DESCRIPTION
| - | - |
| --- | --- |
| Decisions | When adding support for `managed` (https://github.com/ripe-tech/ripe-components-vue/commit/58050938a9e1aebad8af08dedf750027cfe43c73) the default was copied from RIPE White, but in RIPE Pulse it should be `false` to stay retro-compatible. |
