### PR TITLE
#145 Fix the position of order list search input

### DIFF
--- a/vue/components/ui/organisms/listing/listing.vue
+++ b/vue/components/ui/organisms/listing/listing.vue
@@ -171,6 +171,14 @@ body.mobile .listing {
     min-height: 315px;
 }
 
+.listing .container-ripe ::v-deep .container-header .title {
+    display: inline-block;
+}
+
+.listing .container-ripe .container-header .search {
+    float: right;
+}
+
 .listing .filter-ripe ::v-deep table {
     margin-bottom: 0px;
 }

--- a/vue/components/ui/organisms/listing/listing.vue
+++ b/vue/components/ui/organisms/listing/listing.vue
@@ -171,11 +171,7 @@ body.mobile .listing {
     min-height: 315px;
 }
 
-.listing .container-ripe ::v-deep .container-header .title {
-    display: inline-block;
-}
-
-.listing .container-ripe .container-header .search {
+.listing .container-ripe .search {
     float: right;
 }
 
@@ -201,6 +197,10 @@ input[type="text"]:hover {
 input[type="text"]:focus {
     background-color: $white;
     border-color: #aaaaaa;
+}
+
+.listing .container-ripe ::v-deep .title {
+    display: inline-block;
 }
 
 .listing .filter-ripe ::v-deep .lineup > .lineup-item {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Closes https://github.com/ripe-tech/ripe-pulse/issues/145 |
| Decisions | Fix order search input position at listing the components level. |
| Animated GIF | Below |

## Before
#### Storybook
<img width="1511" alt="image" src="https://user-images.githubusercontent.com/24736423/86449799-967b2280-bd10-11ea-812c-d89d9df479f1.png">

#### Pulse
<img width="932" alt="image" src="https://user-images.githubusercontent.com/24736423/86449631-5f0c7600-bd10-11ea-9270-071a41e6698c.png">

## After
#### Storybook
<img width="1511" alt="image" src="https://user-images.githubusercontent.com/24736423/86449946-c4f8fd80-bd10-11ea-98bd-6bf8ff080cb0.png">

#### Pulse
<img width="932" alt="image" src="https://user-images.githubusercontent.com/24736423/86449604-54ea7780-bd10-11ea-8b3b-8c2dca727c9e.png">

