### PR TITLE
Reuse icon component in reaction

### DIFF
--- a/vue/components/ui/atoms/reaction/reaction.vue
+++ b/vue/components/ui/atoms/reaction/reaction.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="reaction" v-bind:class="{ 'user-reacted': userReactedData }" v-on:click="onClick">
         <image-ripe v-bind:src="imgUrl" v-if="hasImage" />
-        <icon v-bind:width="15" v-bind:height="15" v-bind:icon="icon" v-else-if="hasIcon" />
+        <icon v-bind:icon="icon" v-else-if="hasIcon" />
         <div class="emoji" v-else>
             {{ emoji }}
         </div>
@@ -57,6 +57,11 @@
 
 .reaction > .image {
     display: inline-block;
+    height: 15px;
+    width: 15px;
+}
+
+.reaction > .icon {
     height: 15px;
     width: 15px;
 }

--- a/vue/components/ui/atoms/reaction/reaction.vue
+++ b/vue/components/ui/atoms/reaction/reaction.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="reaction" v-bind:class="{ 'user-reacted': userReactedData }" v-on:click="onClick">
-        <img class="image" v-bind:src="imgUrl" v-if="hasImage" />
+        <image-ripe v-bind:src="imgUrl" v-if="hasImage" />
         <icon v-bind:width="15" v-bind:height="15" v-bind:icon="icon" v-else-if="hasIcon" />
         <div class="emoji" v-else>
             {{ emoji }}

--- a/vue/components/ui/atoms/reaction/reaction.vue
+++ b/vue/components/ui/atoms/reaction/reaction.vue
@@ -1,6 +1,7 @@
 <template>
     <div class="reaction" v-bind:class="{ 'user-reacted': userReactedData }" v-on:click="onClick">
-        <img class="image" v-bind:src="imageSrc" v-if="hasImage" />
+        <img class="image" v-bind:src="imgUrl" v-if="hasImage" />
+        <icon v-bind:width="15" v-bind:height="15" v-bind:icon="icon" v-else-if="hasIcon" />
         <div class="emoji" v-else>
             {{ emoji }}
         </div>
@@ -121,17 +122,14 @@ export const Reaction = {
         }
     },
     computed: {
-        imageSrc() {
-            return this.icon ? this.iconPath : this.imgUrl;
-        },
-        iconPath() {
-            return require(`./../../../../assets/icons/${this.icon}.svg`);
-        },
         hasReactions() {
             return this.countData > 0;
         },
         hasImage() {
-            return Boolean(this.imageSrc);
+            return Boolean(this.imgUrl);
+        },
+        hasIcon() {
+            return Boolean(this.icon);
         },
         hasEmoji() {
             return Boolean(this.emoji);


### PR DESCRIPTION
| - | - |
| --- | --- |
| Decisions | Refactor to re-use the `icon` component in `reaction` in order to re-use the "include Ikonate icon" behavior. This was motivated by https://github.com/ripe-tech/ripe-white/pull/507, which adds `reaction` to RIPE White, whereas the icons are in ripe-commons-pluginus, making this change needed in order to: 1. avoid placing `reaction` in ripe-commons-pluginus and 2. avoid duplicating icons in RIPE White and ripe-commons-pluginus. |
