### PR TITLE
Fix button-color hover transition

### DIFF
--- a/vue/components/ui/atoms/button-color/button-color.vue
+++ b/vue/components/ui/atoms/button-color/button-color.vue
@@ -129,7 +129,6 @@
     background-color: $white;
     border: 1px solid #e4e8f0;
     color: $grey;
-    transition: opacity 0.15s ease-in-out;
 }
 
 .button-color.button-color-secondary:hover,


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | -- |
| Dependencies | -- |
| Decisions | When the `button-color` color was set to white, it didn't had a smooth transition when hovering the button. This only happened when `color` was set to white, all other colors have the smooth transition |
| Animated GIF | **Before:**<br>![button-color_white_color_before_fix](https://user-images.githubusercontent.com/22588915/91413129-95fb9580-e842-11ea-9e81-7213f39fcf42.gif)<br><br>**After (slowed down GIF):**<br>![button-color_white_color_after_fix](https://user-images.githubusercontent.com/22588915/91413133-97c55900-e842-11ea-8eb0-022933c09e32.gif) |
