### PR TITLE
Fixed notification show method required options

### DIFF
--- a/vue/components/ui/molecules/notification/notification.vue
+++ b/vue/components/ui/molecules/notification/notification.vue
@@ -166,16 +166,16 @@ export const Notification = {
         });
     },
     methods: {
-        show(options) {
+        show(options = {}) {
             // unpacks the complete set of options for the new notification
             // that is going to be displayed
             const { text, timeout, icon, iconColor, globalEvents, reset = true } = options;
 
             // updates the current local values taking into account
             // the provided set of options
-            this.textData = text;
-            this.iconData = icon;
-            this.iconColorData = iconColor;
+            this.textData = text || this.textData;
+            this.iconData = icon || this.icon;
+            this.iconColorData = iconColor || this.iconColor;
             this.timeoutData = timeout || this.timeout;
             this.globalEventsData = globalEvents || this.globalEvents;
 


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | -- |
| Dependencies | -- |
| Decisions | When calling the method `show()` it was required to pass, at minimum an empty `object` for it to work. Also not all properties were inherited from `props` so you needed to duplicate them and send them as a parameter of `show()`. This PR aims to fix that |
| Animated GIF | -- |
