### PR TITLE
Support for more table features in filter and listing components

### DIFF
--- a/vue/components/ui/molecules/filter/filter.vue
+++ b/vue/components/ui/molecules/filter/filter.vue
@@ -8,6 +8,7 @@
                 v-bind:transition="tableTransition"
                 v-bind:sort="sort"
                 v-bind:reverse="reverse"
+                v-bind:alignment="tableAlignment"
                 v-bind:variant="tableVariant"
                 v-bind:checkboxes="checkboxes"
                 v-bind:checked-items="checkedItems"
@@ -17,8 +18,17 @@
                 <template v-slot="{ item, index }">
                     <slot name="table-item" v-bind:item="item" v-bind:index="index" />
                 </template>
-                <template v-slot:row="{ item, index }">
-                    <slot name="table-row" v-bind:item="item" v-bind:index="index" />
+                <slot
+                    v-bind:name="slot"
+                    v-for="slot in tableSlots"
+                    v-bind:slot="slot.replace('table-', '')"
+                />
+                <template
+                    v-for="slot in tableScopedSlots"
+                    v-bind:slot="slot.replace('table-', '')"
+                    slot-scope="scope"
+                >
+                    <slot v-bind:name="slot" v-bind="scope" />
                 </template>
             </table-ripe>
             <lineup
@@ -120,6 +130,10 @@ export const Filter = {
             type: Array,
             default: () => []
         },
+        tableAlignment: {
+            type: String,
+            default: null
+        },
         tableVariant: {
             type: String,
             default: null
@@ -184,6 +198,12 @@ export const Filter = {
                 start: this.start,
                 limit: this.limit
             };
+        },
+        tableSlots() {
+            return Object.keys(this.$slots).filter(slot => slot.startsWith("table-"));
+        },
+        tableScopedSlots() {
+            return Object.keys(this.$scopedSlots).filter(slot => slot.startsWith("table-"));
         },
         lineupSlots() {
             return Object.keys(this.$slots).filter(slot => slot.startsWith("lineup-"));

--- a/vue/components/ui/organisms/listing/listing.vue
+++ b/vue/components/ui/organisms/listing/listing.vue
@@ -48,6 +48,7 @@
                 v-bind:get-items="getItems"
                 v-bind:get-item-url="getItemUrl"
                 v-bind:table-columns="tableColumns"
+                v-bind:table-alignment="tableAlignment"
                 v-bind:table-variant="tableVariant"
                 v-bind:lineup-fields="lineupFields"
                 v-bind:lineup-columns="lineupColumns"
@@ -215,6 +216,10 @@ export const Listing = {
         tableColumns: {
             type: Array,
             required: true
+        },
+        tableAlignment: {
+            type: String,
+            default: null
         },
         tableVariant: {
             type: String,


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Need to change table in `listing` component. This need first appeared when we wanted to change the field of the table "NAME" https://app.zeplin.io/project/5db732f9c02f1e8327288741/screen/5f194fda1101d97723f02d1a |
| Dependencies | -- |
| Decisions | • Can now use `table-ripe` slots from `listing` or `filter` components by using the prefix "table-" followed by the name of the slot <br>• Added prop tableAlignment |
| Animated GIF | -- |
