### PR TITLE
Details columns in "details-ripe" fill available width

### DIFF
--- a/vue/components/ui/organisms/details/details.vue
+++ b/vue/components/ui/organisms/details/details.vue
@@ -168,7 +168,12 @@
                     />
                     <slot name="image-footer" />
                 </div>
-                <div class="details-column" v-for="column in columns" v-bind:key="column">
+                <div
+                    class="details-column"
+                    v-bind:style="detailsColumnStyle"
+                    v-for="column in columns"
+                    v-bind:key="column"
+                >
                     <slot v-bind:name="value.value" v-for="value in getColumnValues(column - 1)">
                         <div
                             class="label-value"
@@ -553,6 +558,11 @@ export const Details = {
         },
         optionsScopedSlots() {
             return Object.keys(this.$scopedSlots).filter(slot => slot.startsWith("options-"));
+        },
+        detailsColumnStyle() {
+            const base = {};
+            if (!this.imageUrl) base.width = `${100 / this.columns}%`;
+            return base;
         }
     },
     methods: {

--- a/vue/components/ui/organisms/details/details.vue
+++ b/vue/components/ui/organisms/details/details.vue
@@ -384,7 +384,6 @@ body.mobile .container-ripe .title {
     font-size: 0px;
     padding: 0px 24px 40px 24px;
     text-align: left;
-    white-space: nowrap;
 }
 
 .container-ripe .details-column {

--- a/vue/components/ui/organisms/details/details.vue
+++ b/vue/components/ui/organisms/details/details.vue
@@ -391,7 +391,6 @@ body.mobile .container-ripe .title {
     display: inline-block;
     padding: 20px 20px 0px 0px;
     vertical-align: top;
-    width: 15%;
 }
 
 body.tablet .container-ripe .details-column,
@@ -519,6 +518,10 @@ export const Details = {
             type: Array,
             required: true
         },
+        columnWidth: {
+            type: String,
+            default: null
+        },
         imageUrl: {
             type: String,
             default: null
@@ -587,8 +590,11 @@ export const Details = {
             return Object.keys(this.$scopedSlots).filter(slot => slot.startsWith("options-"));
         },
         detailsColumnStyle() {
-            const base = {};
-            if (!this.imageUrl) base.width = `${100 / this.columns}%`;
+            const base = {
+                width: this.columnWidth
+                    ? this.columnWidth
+                    : `${(this.imageUrl ? 60 : 100) / this.columns}%`
+            };
             return base;
         }
     },

--- a/vue/components/ui/organisms/details/details.vue
+++ b/vue/components/ui/organisms/details/details.vue
@@ -384,6 +384,7 @@ body.mobile .container-ripe .title {
     font-size: 0px;
     padding: 0px 24px 40px 24px;
     text-align: left;
+    white-space: nowrap;
 }
 
 .container-ripe .details-column {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-registry/issues/1 |
| Dependencies | -- |
| Decisions | Details columns fill all the available space when there isn't any side image. This PR was open because if we use `details-ripe` without an image the columns aren't spaced equally through the container full width. The need for this came when trying to implement `person-show` page https://app.zeplin.io/project/5db732f9c02f1e8327288741/screen/5f194fdb73a8666bc56f6f70 |
| Animated GIFs | ![details-details_columns_width_improvement](https://user-images.githubusercontent.com/22588915/91537883-e0e2df00-e90e-11ea-8bb4-540aee672108.gif)<br><br>**Needed for `person-show`:** ![person-show_using_details](https://user-images.githubusercontent.com/22588915/91558806-dd5f5000-e92e-11ea-8d53-606df9a1ce4f.gif)<br><br>**It changed the UI of some projects, for example ripe-sputnik-ui. I personally think it is better now**<br>**Before:**<br>![Captura de ecrã 2020-08-28 às 09 07 03](https://user-images.githubusercontent.com/22588915/91537450-3b2f7000-e90e-11ea-864e-9f72b05b32e5.png)<br>**After:**<br>![Captura de ecrã 2020-08-28 às 09 06 47](https://user-images.githubusercontent.com/22588915/91537444-3965ac80-e90e-11ea-958d-513eedb7b372.png) |
