### PR TITLE
Added slot "selected" to "select" component

### DIFF
--- a/vue/components/ui/molecules/select/select.vue
+++ b/vue/components/ui/molecules/select/select.vue
@@ -34,7 +34,9 @@
                 v-on:keydown.enter.exact="onEnterKey"
                 v-on:keydown.space.exact="onSpaceKey"
             >
-                {{ buttonText }}
+                <slot v-bind:name="'selected'">
+                    {{ buttonText }}
+                </slot>
             </div>
             <dropdown
                 v-bind:items="options"


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-registry/issues/1 |
| Dependencies | -- |
| Decisions | Added slot to `select` selected value so it's possible to override what is show to the user after selecting an option |
| Animated GIF | ![select_selected_slot](https://user-images.githubusercontent.com/22588915/91874940-b8dadf00-ec72-11ea-93ac-41a477d9f8fd.gif) |