### PR TITLE
Fixed header-buttons aligment with search bar

### DIFF
--- a/vue/components/ui/organisms/listing/listing.vue
+++ b/vue/components/ui/organisms/listing/listing.vue
@@ -172,6 +172,10 @@ body.mobile .listing {
     min-height: 315px;
 }
 
+.listing .container-ripe .search {
+    vertical-align: middle;
+}
+
 .listing .filter-ripe ::v-deep table {
     margin-bottom: 0px;
 }


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | -- |
| Dependencies | -- |
| Decisions | Search bar in `listing` wasn't aligned vertically with the header buttons, this PR tries to fix that |
| Animated GIF | **Before:**<br><img width="1473" alt="imagem" src="https://user-images.githubusercontent.com/22588915/91976605-1e81a680-ed19-11ea-97ba-28d2ace43d16.png"><br><br>**After fix:**<br><img width="1473" alt="imagem" src="https://user-images.githubusercontent.com/22588915/91976654-32c5a380-ed19-11ea-98fe-17fced8d8937.png"> |
