### PR TITLE
Fix CSS import

### DIFF
--- a/css/all.scss
+++ b/css/all.scss
@@ -1,7 +1,7 @@
-@import "css/animations.scss";
-@import "css/layout.scss";
-@import "css/transitions.scss";
-@import "css/variables.scss";
+@import "animations.scss";
+@import "layout.scss";
+@import "transitions.scss";
+@import "variables.scss";
 @import url("https://fonts.googleapis.com/css?family=Lato:100,100i,300,300i,400,400i,700,700i,900,900i");
 
 * {

--- a/css/variables.scss
+++ b/css/variables.scss
@@ -1,4 +1,4 @@
-@import "css/colors.scss";
+@import "colors.scss";
 
 $main-color: #1d1d1d;
 $higher-color: #000000;

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
         "jsdom-global": "^3.0.2",
         "mochapack": "^2.0.3",
         "node-fetch": "^2.6.0",
+        "null-loader": "^4.0.0",
         "svgo": "^1.3.2",
         "url-loader": "^4.1.0",
         "uxf-webpack": "^0.6.0"

--- a/vue/test/webpack.config.js
+++ b/vue/test/webpack.config.js
@@ -34,6 +34,10 @@ config.module.rules.push({
         }
     ]
 });
+config.module.rules.push({
+    test: /\.(css|scss|sass)$/,
+    use: ["null-loader"]
+});
 
 config.module.rules.find(rule => rule.loader === "vue-loader").options.optimizeSSR = false;
 


### PR DESCRIPTION
| - | - |
| --- | --- |
| Decisions | Load no CSS when running tests (coherent with https://github.com/ripe-tech/ripe-sdk-components-react/blob/master/react/test/webpack.config.js). This fixes both https://github.com/ripe-tech/ripe-components-vue/pull/358 and https://github.com/ripe-tech/ripe-components-vue/actions/runs/235778755 |
