### PR TITLE
Support for "router-link" in "breadcrumbs"

### DIFF
--- a/vue/components/ui/atoms/breadcrumbs/breadcrumbs.vue
+++ b/vue/components/ui/atoms/breadcrumbs/breadcrumbs.vue
@@ -4,26 +4,19 @@
             <template v-if="index !== breadcrumbs.length - 1">
                 <router-link
                     v-bind:to="breadcrumb.href"
-                    v-if="typeof breadcrumb.href === 'object'"
+                    v-slot="{ href, navigate }"
                     v-bind:key="index"
                 >
                     <link-ripe
                         class="breadcrumb-link"
                         v-bind:text="breadcrumb.text"
+                        v-bind:href="href"
+                        v-bind:target="breadcrumb.target"
                         v-bind:hover="'color'"
                         v-bind:style="partStyle"
+                        v-on:click="navigate"
                     />
                 </router-link>
-                <link-ripe
-                    class="breadcrumb-link"
-                    v-bind:text="breadcrumb.text"
-                    v-bind:href="breadcrumb.href"
-                    v-bind:target="breadcrumb.target"
-                    v-bind:hover="'color'"
-                    v-bind:style="partStyle"
-                    v-else
-                    v-bind:key="index"
-                />
                 <div
                     class="breadcrumb-separator"
                     v-bind:style="separatorStyle"

--- a/vue/components/ui/atoms/breadcrumbs/breadcrumbs.vue
+++ b/vue/components/ui/atoms/breadcrumbs/breadcrumbs.vue
@@ -2,6 +2,18 @@
     <div class="breadcrumbs">
         <template v-for="(breadcrumb, index) in breadcrumbs">
             <template v-if="index !== breadcrumbs.length - 1">
+                <router-link
+                    v-bind:to="breadcrumb.href"
+                    v-if="typeof breadcrumb.href === 'object'"
+                    v-bind:key="index"
+                >
+                    <link-ripe
+                        class="breadcrumb-link"
+                        v-bind:text="breadcrumb.text"
+                        v-bind:hover="'color'"
+                        v-bind:style="partStyle"
+                    />
+                </router-link>
                 <link-ripe
                     class="breadcrumb-link"
                     v-bind:text="breadcrumb.text"
@@ -9,6 +21,7 @@
                     v-bind:target="breadcrumb.target"
                     v-bind:hover="'color'"
                     v-bind:style="partStyle"
+                    v-else
                     v-bind:key="index"
                 />
                 <div


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Avoiding having paths in `breadcrumbs`: https://github.com/ripe-tech/ripe-registry-ui/pull/5#discussion_r482399741 |
| Dependencies | -- |
| Decisions | Component `breadcrumbs` now uses `router-link` when the property `href` is an `object`.  |
| Animated GIF | -- |
