### PR TITLE
Added create button to "listing" component

### DIFF
--- a/vue/components/ui/organisms/listing/listing.stories.js
+++ b/vue/components/ui/organisms/listing/listing.stories.js
@@ -61,6 +61,10 @@ storiesOf("Organisms", module)
                 default: () => {
                     return {};
                 }
+            },
+            createUrl: {
+                type: String,
+                default: text("Create Url", "https://www.platforme.com/")
             }
         },
         data: function() {
@@ -108,6 +112,7 @@ storiesOf("Organisms", module)
                     v-bind:container-mode="containerMode"
                     v-bind:checkboxes="checkboxes"
                     v-bind:checked-items.sync="checkedItemsData"
+                    v-bind:create-url="createUrl"
                 >
                     <template v-slot:icons>
                         <img v-bind:src="img" v-bind:style="imgStyle" />

--- a/vue/components/ui/organisms/listing/listing.vue
+++ b/vue/components/ui/organisms/listing/listing.vue
@@ -31,6 +31,15 @@
             </template>
             <template v-slot:header-buttons-inside-after>
                 <slot v-bind:name="'header-buttons-inside-after'" />
+                <router-link class="button-create" v-bind:to="createUrl">
+                    <button-color
+                        v-bind:text="`Create ${name}`"
+                        v-bind:size="'small'"
+                        v-bind:alignment="'left'"
+                        v-bind:icon="'add'"
+                        v-bind:min-width="0"
+                    />
+                </router-link>
                 <slot name="header-search">
                     <search
                         v-bind:variant="'dark'"
@@ -169,6 +178,11 @@ body.mobile .listing {
     opacity: 0;
 }
 
+.listing .container-ripe .search {
+    margin: 0px 0px 0px 8px;
+    vertical-align: middle;
+}
+
 .listing.empty .container-ripe {
     min-height: 315px;
 }
@@ -296,6 +310,10 @@ export const Listing = {
         containerHeaderButtons: {
             type: Array,
             default: () => []
+        },
+        createUrl: {
+            type: String | Object,
+            default: "#"
         }
     },
     data: function() {

--- a/vue/components/ui/organisms/listing/listing.vue
+++ b/vue/components/ui/organisms/listing/listing.vue
@@ -31,13 +31,20 @@
             </template>
             <template v-slot:header-buttons-inside-after>
                 <slot v-bind:name="'header-buttons-inside-after'" />
-                <router-link class="button-create" v-bind:to="createUrl">
+                <router-link
+                    class="button-create"
+                    v-bind:to="createUrl"
+                    v-if="createUrl"
+                    v-slot="{ href, navigate }"
+                >
                     <button-color
                         v-bind:text="`Create ${name}`"
                         v-bind:size="'small'"
                         v-bind:alignment="'left'"
                         v-bind:icon="'add'"
                         v-bind:min-width="0"
+                        v-bind:href="href"
+                        v-on:click="navigate"
                     />
                 </router-link>
                 <slot name="header-search">
@@ -178,6 +185,10 @@ body.mobile .listing {
     opacity: 0;
 }
 
+.listing .button-create {
+    display: inline-block;
+}
+
 .listing .container-ripe .search {
     margin: 0px 0px 0px 8px;
     vertical-align: middle;
@@ -313,7 +324,7 @@ export const Listing = {
         },
         createUrl: {
             type: String | Object,
-            default: "#"
+            default: null
         }
     },
     data: function() {

--- a/vue/components/ui/organisms/listing/listing.vue
+++ b/vue/components/ui/organisms/listing/listing.vue
@@ -185,7 +185,7 @@ body.mobile .listing {
     opacity: 0;
 }
 
-.listing .button-create {
+.listing .container-ripe .button-create {
     display: inline-block;
 }
 

--- a/vue/components/ui/organisms/listing/listing.vue
+++ b/vue/components/ui/organisms/listing/listing.vue
@@ -187,6 +187,7 @@ body.mobile .listing {
 
 .listing .container-ripe .button-create {
     display: inline-block;
+    vertical-align: middle;
 }
 
 .listing .container-ripe .search {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Request to add button-colors to `listing` (ripe-tech/ripe-registry-ui#3) |
| Dependencies | -- |
| Decisions | Added create button to `listing`. It is enable via the optional prop `createUrl` supports `string` or an `object` which then is used by `router-link` |
| Animated GIF | ![listing_create_button](https://user-images.githubusercontent.com/22588915/92131752-439c1500-edfe-11ea-88ef-c7ad6e566681.gif) |
