### PR TITLE
Buttons in footer only in details

### DIFF
--- a/vue/components/ui/atoms/container/container.vue
+++ b/vue/components/ui/atoms/container/container.vue
@@ -103,26 +103,6 @@ body.mobile .container-ripe > .container-header {
     text-transform: capitalize;
     user-select: none;
 }
-
-body.tablet .container-ripe > .container-header > .header-buttons,
-body.mobile .container-ripe > .container-header > .header-buttons {
-    animation: none;
-    background-color: $white;
-    border-top: 1px solid $light-white;
-    bottom: 0px;
-    display: flex;
-    left: 0px;
-    position: fixed;
-    text-align: justify;
-    transition: none;
-    width: 100%;
-    z-index: 10;
-}
-
-body.tablet .container-ripe > .container-header > .header-buttons > .header-button,
-body.mobile .container-ripe > .container-header > .header-buttons > .header-button {
-    flex: 1;
-}
 </style>
 
 <script>

--- a/vue/components/ui/organisms/details/details.vue
+++ b/vue/components/ui/organisms/details/details.vue
@@ -279,6 +279,21 @@ body.mobile .container-ripe {
     padding-top: 140px;
 }
 
+body.tablet .container-ripe .header-buttons,
+body.mobile .container-ripe .header-buttons {
+    animation: none;
+    background-color: $white;
+    border-top: 1px solid $light-white;
+    bottom: 0px;
+    display: flex;
+    left: 0px;
+    position: fixed;
+    text-align: justify;
+    transition: none;
+    width: 100%;
+    z-index: 10;
+}
+
 .container-ripe .header-buttons > .header-button {
     display: inline-block;
 }


### PR DESCRIPTION
| - | - |
| --- | --- |
| Decisions | Moved the "floating buttons in bottom" style from `container-ripe` to `details`. |
| Animated GIF | ![image](https://user-images.githubusercontent.com/3048875/92136054-78f73180-ee03-11ea-9345-37dcef8a5e31.png) ![image](https://user-images.githubusercontent.com/3048875/92136192-9fb56800-ee03-11ea-98bf-148b89c98513.png) |
