### PR TITLE
Fix listing default sort

### DIFF
--- a/vue/components/ui/organisms/listing/listing.vue
+++ b/vue/components/ui/organisms/listing/listing.vue
@@ -302,7 +302,7 @@ export const Listing = {
         },
         defaultSort: {
             type: String,
-            default: "name"
+            default: "id"
         },
         useQuery: {
             type: Boolean,


### PR DESCRIPTION
| - | - |
| --- | --- |
| Decisions | Fix the sorting regression caused by https://github.com/ripe-tech/ripe-components-vue/pull/366 . |
