### PR TITLE
Add maxLength to input-ripe component

### DIFF
--- a/vue/components/ui/atoms/input/input.stories.js
+++ b/vue/components/ui/atoms/input/input.stories.js
@@ -66,6 +66,9 @@ storiesOf("Atoms", module)
             },
             height: {
                 default: number("Height", null)
+            },
+            maxLength: {
+                default: number("Max Length", null)
             }
         },
         data: function() {
@@ -94,7 +97,8 @@ storiesOf("Atoms", module)
                         v-bind:monospaced="monospaced"
                         v-bind:width="width"
                         v-bind:min-width="minWidth"
-                        v-bind:height="height" />
+                        v-bind:height="height"
+                        v-bind:maxLength="maxLength" />
                 </form-input>
                 <p>Text: {{ valueData }}</p>
             </div>

--- a/vue/components/ui/atoms/input/input.vue
+++ b/vue/components/ui/atoms/input/input.vue
@@ -7,6 +7,7 @@
         v-bind:value="value"
         v-bind:placeholder="placeholder"
         v-bind:disabled="disabled"
+        v-bind:maxLength="maxLength"
         ref="input"
         v-on:input="event => onInput(event.target.value)"
         v-on:focus="onFocus"
@@ -146,6 +147,10 @@ export const Input = {
         },
         validationMessage: {
             type: String,
+            default: null
+        },
+        maxLength: {
+            type: Number,
             default: null
         }
     },


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-retail-vendors/issues/48 |
| Decisions | Every personalization has a maximum number of characters, and that should be handled by the `input-ripe` component. Backporting from https://github.com/ripe-tech/ripe-white/pull/583 |