### PR TITLE
Remove padding when text is null

### DIFF
--- a/vue/components/ui/atoms/button-color/button-color.vue
+++ b/vue/components/ui/atoms/button-color/button-color.vue
@@ -18,7 +18,6 @@
             v-bind:color="iconColor"
             v-bind:width="iconSize"
             v-bind:height="iconSize"
-            v-bind:style="iconStyle"
             v-if="icon && !loading"
         />
         <icon
@@ -27,7 +26,6 @@
             v-bind:color="iconHoverColor"
             v-bind:width="iconSize"
             v-bind:height="iconSize"
-            v-bind:style="iconStyle"
             v-if="icon && !loading"
         />
         <span v-show="!loading">
@@ -246,7 +244,13 @@
     float: left;
     height: 22px;
     margin-top: 8px;
+    padding-right: 12px;
     width: 22px;
+}
+
+.button-color.button-color-no-text .icon,
+.button-color.button-color-no-text .icon-hover {
+    padding-right: 0px;
 }
 
 .button-color.button-color-small .icon,
@@ -392,6 +396,7 @@ export const ButtonColor = {
             const base = {
                 "button-color-secondary": this.secondary,
                 "button-color-icon": this.icon,
+                "button-color-no-text": !this.text && !this.$slots.default,
                 disabled: this.disabled,
                 loading: this.loading
             };
@@ -407,11 +412,6 @@ export const ButtonColor = {
             }
 
             return base;
-        },
-        iconStyle() {
-            return {
-                "padding-right": this.text || this.$slots.default ? 12 : 0
-            };
         }
     }
 };

--- a/vue/components/ui/atoms/button-color/button-color.vue
+++ b/vue/components/ui/atoms/button-color/button-color.vue
@@ -18,6 +18,7 @@
             v-bind:color="iconColor"
             v-bind:width="iconSize"
             v-bind:height="iconSize"
+            v-bind:style="iconStyle"
             v-if="icon && !loading"
         />
         <icon
@@ -26,6 +27,7 @@
             v-bind:color="iconHoverColor"
             v-bind:width="iconSize"
             v-bind:height="iconSize"
+            v-bind:style="iconStyle"
             v-if="icon && !loading"
         />
         <span v-show="!loading">
@@ -244,7 +246,6 @@
     float: left;
     height: 22px;
     margin-top: 8px;
-    padding-right: 12px;
     width: 22px;
 }
 
@@ -406,6 +407,11 @@ export const ButtonColor = {
             }
 
             return base;
+        },
+        iconStyle() {
+            return {
+                "padding-right": this.text || this.$slots.default ? 12 : 0
+            };
         }
     }
 };


### PR DESCRIPTION
| - | - |
| --- | --- |
| Decisions |The need for this came from working on this [issue](https://github.com/ripe-tech/ripe-pulse/issues/146) on Pulse, noticing the disalignment of icon in the button. Keeping the padding when there is a slot because most usages of this component use the slot with just text. |
