### PR TITLE
Support select slots in form-ripe

### DIFF
--- a/vue/components/ui/organisms/form/form.vue
+++ b/vue/components/ui/organisms/form/form.vue
@@ -46,7 +46,10 @@
                                             <slot v-bind:name="`select-${field.value}-selected`" />
                                         </template>
                                         <template v-slot="{ item }">
-                                            <slot v-bind:name="`select-${field.value}`" v-bind:item="item" />
+                                            <slot
+                                                v-bind:name="`select-${field.value}`"
+                                                v-bind:item="item"
+                                            />
                                         </template>
                                     </select-ripe>
                                     <switcher

--- a/vue/components/ui/organisms/form/form.vue
+++ b/vue/components/ui/organisms/form/form.vue
@@ -43,10 +43,10 @@
                                         v-on:update:value="value => onValue(field.value, value)"
                                     >
                                         <template v-slot:selected>
-                                            <slot name="select-selected" />
+                                            <slot v-bind:name="`select-${field.value}-selected`" />
                                         </template>
                                         <template v-slot="{ item }">
-                                            <slot name="select" v-bind:item="item" />
+                                            <slot v-bind:name="`select-${field.value}`" v-bind:item="item" />
                                         </template>
                                     </select-ripe>
                                     <switcher

--- a/vue/components/ui/organisms/form/form.vue
+++ b/vue/components/ui/organisms/form/form.vue
@@ -41,7 +41,14 @@
                                         v-bind:value="values[field.value]"
                                         v-else-if="field.type === 'select'"
                                         v-on:update:value="value => onValue(field.value, value)"
-                                    />
+                                    >
+                                        <template v-slot:selected>
+                                            <slot name="select-selected" />
+                                        </template>
+                                        <template v-slot="{ item }">
+                                            <slot name="select" v-bind:item="item" />
+                                        </template>
+                                    </select-ripe>
                                     <switcher
                                         v-bind="field.props"
                                         v-bind:checked="values[field.value]"


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-registry-ui/pull/16 |
| Dependencies | -- |
| Decisions | Need to use the select slots to be able to customize the select values UI<br>Example of slots in use below, take notice in the two selects that have their entries with an avatar, name and email|
| Animated GIF | <br>![client-create](https://user-images.githubusercontent.com/22588915/92007231-93ff6e00-ed3d-11ea-8b9d-0219f01ddddf.gif) |
