### PR TITLE
Improved select slots

### DIFF
--- a/vue/components/ui/molecules/select/select.vue
+++ b/vue/components/ui/molecules/select/select.vue
@@ -34,7 +34,7 @@
                 v-on:keydown.enter.exact="onEnterKey"
                 v-on:keydown.space.exact="onSpaceKey"
             >
-                <slot v-bind:name="'selected'">
+                <slot v-bind:name="'selected'" v-bind:item="selectedOption">
                     {{ buttonText }}
                 </slot>
             </div>
@@ -425,10 +425,11 @@ export const Select = {
         }
     },
     computed: {
+        selectedOption() {
+            return this.options ? this.options[this.valueIndex] : null;
+        },
         buttonText() {
-            return this.options && this.options[this.valueIndex]
-                ? this.options[this.valueIndex].label
-                : this.placeholder;
+            return this.selectedOption ? this.selectedOption.label : this.placeholder;
         },
         selected() {
             const selected = {};

--- a/vue/components/ui/organisms/form/form.vue
+++ b/vue/components/ui/organisms/form/form.vue
@@ -19,10 +19,11 @@
                             <template v-for="field in section.fields">
                                 <form-input
                                     class="section-field"
-                                    v-bind:header="
-                                        field.label !== undefined ? field.label : field.value
-                                    "
-                                    v-bind="field.formInputProps"
+                                    v-bind:header="fieldLabel(field)"
+                                    v-bind="{
+                                        ...requiredFieldProps(field),
+                                        ...field.formInputProps
+                                    }"
                                     v-bind:key="field.value"
                                 >
                                     <input-ripe
@@ -193,6 +194,7 @@ export const Form = {
     },
     data: function() {
         return {
+            saveAttempted: false,
             saving: false,
             deleting: false,
             valuesData: this.values
@@ -234,6 +236,18 @@ export const Form = {
             };
             return base;
         },
+        fieldLabel(field) {
+            return field.label !== undefined ? field.label : field.value;
+        },
+        requiredFieldProps(field) {
+            return field.required
+                ? {
+                      title: `${this.fieldLabel(field)} required`,
+                      "header-variant":
+                          this.saveAttempted && !this.valuesData[field.value] ? "error" : null
+                  }
+                : {};
+        },
         goNext() {
             if (!this.navigation) return;
             if (!this.next) return;
@@ -253,7 +267,7 @@ export const Form = {
         },
         async save() {
             if (!this.onSave) return;
-            this.saving = true;
+            this.saving = this.saveAttempted = true;
             try {
                 await this.onSave(this.values);
             } finally {

--- a/vue/components/ui/organisms/form/form.vue
+++ b/vue/components/ui/organisms/form/form.vue
@@ -42,13 +42,21 @@
                                         v-else-if="field.type === 'select'"
                                         v-on:update:value="value => onValue(field.value, value)"
                                     >
-                                        <template v-slot:selected>
-                                            <slot v-bind:name="`select-${field.value}-selected`" />
+                                        <template v-slot:selected="{ item }">
+                                            <slot
+                                                v-bind:name="'select-selected'"
+                                                v-bind:item="item"
+                                            >
+                                                <slot
+                                                    v-bind:name="`${field.value}-select-selected`"
+                                                    v-bind:item="item"
+                                                />
+                                            </slot>
                                         </template>
                                         <template v-slot="{ item }">
                                             <slot v-bind:name="'select'" v-bind:item="item">
                                                 <slot
-                                                    v-bind:name="`select-${field.value}`"
+                                                    v-bind:name="`${field.value}-select`"
                                                     v-bind:item="item"
                                                 />
                                             </slot>

--- a/vue/components/ui/organisms/form/form.vue
+++ b/vue/components/ui/organisms/form/form.vue
@@ -19,11 +19,10 @@
                             <template v-for="field in section.fields">
                                 <form-input
                                     class="section-field"
-                                    v-bind:header="fieldLabel(field)"
-                                    v-bind="{
-                                        ...requiredFieldProps(field),
-                                        ...field.formInputProps
-                                    }"
+                                    v-bind:header="
+                                        field.label !== undefined ? field.label : field.value
+                                    "
+                                    v-bind="field.formInputProps"
                                     v-bind:key="field.value"
                                 >
                                     <input-ripe
@@ -222,7 +221,6 @@ export const Form = {
     },
     data: function() {
         return {
-            saveAttempted: false,
             saving: false,
             deleting: false,
             valuesData: this.values
@@ -264,18 +262,6 @@ export const Form = {
             };
             return base;
         },
-        fieldLabel(field) {
-            return field.label !== undefined ? field.label : field.value;
-        },
-        requiredFieldProps(field) {
-            return field.required
-                ? {
-                      title: `${this.fieldLabel(field)} required`,
-                      "header-variant":
-                          this.saveAttempted && !this.valuesData[field.value] ? "error" : null
-                  }
-                : {};
-        },
         goNext() {
             if (!this.navigation) return;
             if (!this.next) return;
@@ -295,7 +281,7 @@ export const Form = {
         },
         async save() {
             if (!this.onSave) return;
-            this.saving = this.saveAttempted = true;
+            this.saving = true;
             try {
                 await this.onSave(this.values);
 


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-registry/issues/1 |
| Dependencies | -- |
| Decisions | • Renamed `form-ripe`'s select slots <br>• Support for item in `select` selected slot |
| Animated GIF | ![example](https://user-images.githubusercontent.com/22588915/94424486-361a4680-0182-11eb-973c-ba987c834fbd.gif) |
