### PR TITLE
Field types improvements

### DIFF
--- a/vue/components/ui/organisms/form/form.stories.js
+++ b/vue/components/ui/organisms/form/form.stories.js
@@ -19,11 +19,12 @@ storiesOf("Organisms", module)
                                 fields: [
                                     {
                                         value: "username",
-                                        type: "string"
+                                        type: "text"
                                     },
                                     {
                                         value: "email",
-                                        type: "email"
+                                        type: "text",
+                                        meta: "email"
                                     }
                                 ]
                             },
@@ -32,11 +33,12 @@ storiesOf("Organisms", module)
                                 fields: [
                                     {
                                         value: "username2",
-                                        type: "string"
+                                        type: "text"
                                     },
                                     {
                                         value: "email2",
-                                        type: "email"
+                                        type: "text",
+                                        meta: "email"
                                     }
                                 ]
                             }
@@ -47,11 +49,17 @@ storiesOf("Organisms", module)
                                 fields: [
                                     {
                                         value: "username3",
-                                        type: "string"
+                                        type: "text"
                                     },
                                     {
-                                        value: "email3",
-                                        type: "email"
+                                        value: "description",
+                                        type: "text",
+                                        meta: "long"
+                                    },
+                                    {
+                                        value: "imageUrl",
+                                        type: "text",
+                                        meta: "image-url"
                                     }
                                 ]
                             }
@@ -64,7 +72,8 @@ storiesOf("Organisms", module)
                                 fields: [
                                     {
                                         value: "age",
-                                        type: "number"
+                                        type: "text",
+                                        meta: "number"
                                     }
                                 ]
                             }
@@ -75,7 +84,8 @@ storiesOf("Organisms", module)
                                 fields: [
                                     {
                                         value: "age2",
-                                        type: "number"
+                                        type: "text",
+                                        meta: "number"
                                     }
                                 ]
                             }
@@ -94,7 +104,9 @@ storiesOf("Organisms", module)
                     username3: "My username 3",
                     email3: "c@c.pt",
                     age: 1,
-                    age2: 2
+                    age2: 2,
+                    description: "",
+                    imageUrl: "https://pepethefrogfaith.files.wordpress.com/2016/09/pepe.png?w=640"
                 }
             };
         },

--- a/vue/components/ui/organisms/form/form.vue
+++ b/vue/components/ui/organisms/form/form.vue
@@ -27,10 +27,32 @@
                                     v-bind:key="field.value"
                                 >
                                     <input-ripe
-                                        v-bind:type="field.type"
+                                        v-bind:type="field.meta"
                                         v-bind="field.props"
                                         v-bind:value="values[field.value]"
-                                        v-if="field.type === 'text' && !field.meta"
+                                        v-if="
+                                            field.type === 'text' &&
+                                                [
+                                                    null,
+                                                    undefined,
+                                                    'string',
+                                                    'number',
+                                                    'email',
+                                                    'input',
+                                                    'image-url'
+                                                ].includes(field.meta)
+                                        "
+                                        v-on:update:value="value => onValue(field.value, value)"
+                                    />
+                                    <image-ripe
+                                        class="text-image"
+                                        v-bind:src="values[field.value]"
+                                        v-if="field.type === 'text' && field.meta === 'image-url'"
+                                    />
+                                    <textarea-ripe
+                                        v-bind="field.props"
+                                        v-bind:value="values[field.value]"
+                                        v-else-if="field.type === 'text' && field.meta === 'long'"
                                         v-on:update:value="value => onValue(field.value, value)"
                                     />
                                     <select-ripe
@@ -64,12 +86,6 @@
                                         v-bind:checked="values[field.value]"
                                         v-else-if="field.type === 'boolean'"
                                         v-on:update:checked="value => onValue(field.value, value)"
-                                    />
-                                    <textarea-ripe
-                                        v-bind="field.props"
-                                        v-bind:value="values[field.value]"
-                                        v-else-if="field.type === 'text' && field.meta === 'long'"
-                                        v-on:update:value="value => onValue(field.value, value)"
                                     />
                                     <files-uploader
                                         v-bind="field.props"
@@ -142,6 +158,18 @@ body.mobile .form > .form-form > .tabs .column {
 
 .form > .form-form > .tabs .column > .section > .section-field:last-child {
     margin-bottom: 0px;
+}
+
+.form > .form-form > .tabs .column > .section > .section-field ::v-deep .content {
+    text-align: center;
+}
+
+.form > .form-form > .tabs .column > .section > .section-field .text-image {
+    box-sizing: border-box;
+    margin: 20px 0px 0px 0px;
+    max-height: 70px;
+    max-width: 100%;
+    padding: 0px 10px 0px 10px;
 }
 </style>
 

--- a/vue/components/ui/organisms/form/form.vue
+++ b/vue/components/ui/organisms/form/form.vue
@@ -27,7 +27,7 @@
                                     v-bind:key="field.value"
                                 >
                                     <input-ripe
-                                        v-bind:type="field.meta"
+                                        v-bind:type="inputType(field)"
                                         v-bind="field.props"
                                         v-bind:value="values[field.value]"
                                         v-if="
@@ -47,12 +47,12 @@
                                     <image-ripe
                                         class="text-image"
                                         v-bind:src="values[field.value]"
-                                        v-if="field.type === 'text' && field.meta === 'image-url'"
+                                        v-else-if="field.meta === 'image-url'"
                                     />
                                     <textarea-ripe
                                         v-bind="field.props"
                                         v-bind:value="values[field.value]"
-                                        v-else-if="field.type === 'text' && field.meta === 'long'"
+                                        v-else-if="field.meta === 'longtext'"
                                         v-on:update:value="value => onValue(field.value, value)"
                                     />
                                     <select-ripe
@@ -160,13 +160,10 @@ body.mobile .form > .form-form > .tabs .column {
     margin-bottom: 0px;
 }
 
-.form > .form-form > .tabs .column > .section > .section-field ::v-deep .content {
-    text-align: center;
-}
-
 .form > .form-form > .tabs .column > .section > .section-field .text-image {
     box-sizing: border-box;
-    margin: 20px 0px 0px 0px;
+    display: block;
+    margin: 20px auto 0px auto;
     max-height: 70px;
     max-width: 100%;
     padding: 0px 10px 0px 10px;
@@ -301,6 +298,9 @@ export const Form = {
                 width: this.isTabletWidth() || this.isMobileWidth() ? null : width
             };
             return base;
+        },
+        inputType(field) {
+            return field.meta;
         },
         goNext() {
             if (!this.navigation) return;

--- a/vue/components/ui/organisms/form/form.vue
+++ b/vue/components/ui/organisms/form/form.vue
@@ -30,11 +30,7 @@
                                         v-bind:type="field.type"
                                         v-bind="field.props"
                                         v-bind:value="values[field.value]"
-                                        v-if="
-                                            ['string', 'number', 'email', 'input'].includes(
-                                                field.type
-                                            )
-                                        "
+                                        v-if="field.type === 'text' && !field.meta"
                                         v-on:update:value="value => onValue(field.value, value)"
                                     />
                                     <select-ripe
@@ -72,7 +68,7 @@
                                     <textarea-ripe
                                         v-bind="field.props"
                                         v-bind:value="values[field.value]"
-                                        v-else-if="field.type === 'textarea'"
+                                        v-else-if="field.type === 'text' && field.meta === 'long'"
                                         v-on:update:value="value => onValue(field.value, value)"
                                     />
                                     <files-uploader


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue |https://github.com/ripe-tech/ripe-components-vue/pull/378#issuecomment-701349578 |
| Dependencies | -- |
| Decisions | • Can use `meta` to specify the input type <br>• To use textarea, instead of just specifying type "textarea" we now do type "text" and  meta "long" <br>• Added new image url input type |
| Screenshot | <img width="1319" alt="imagem" src="https://user-images.githubusercontent.com/22588915/94795317-1a5aae80-03d5-11eb-9663-354acc2481f8.png"> |