### PR TITLE
#172 Add symbol position prop to component input-symbol

### DIFF
--- a/vue/components/ui/molecules/input-symbol/input-symbol.stories.js
+++ b/vue/components/ui/molecules/input-symbol/input-symbol.stories.js
@@ -56,6 +56,17 @@ storiesOf("Molecules", module)
             symbol: {
                 default: text("Symbol", "€")
             },
+            symbolPosition: {
+                default: select(
+                    "Symbol Position",
+                    {
+                        Unset: null,
+                        Left: "left",
+                        Right: "right"
+                    },
+                    "right"
+                )
+            },
             placeholder: {
                 default: text("Placeholder", "This is a placeholder")
             },
@@ -91,7 +102,8 @@ storiesOf("Molecules", module)
                     v-bind:type="type"
                     v-bind:disabled="disabled"
                     v-bind:placeholder="placeholder"
-                    v-bind:symbol="symbol" />
+                    v-bind:symbol="symbol"
+                    v-bind:symbol-position="symbolPosition" />
                 <p>Text: {{ valueData }}</p>
             </div>
         `

--- a/vue/components/ui/molecules/input-symbol/input-symbol.vue
+++ b/vue/components/ui/molecules/input-symbol/input-symbol.vue
@@ -1,5 +1,12 @@
 <template>
     <div class="input-symbol" v-bind:class="classes" v-bind:style="style">
+        <div
+            class="symbol symbol-left"
+            v-bind:style="symbolStyle"
+            v-show="symbolPosition === 'left'"
+        >
+            {{ symbol }}
+        </div>
         <input-ripe
             v-bind:value.sync="valueData"
             v-bind:variant="variant"
@@ -15,7 +22,11 @@
             v-on:blur="onBlur"
             v-on:focus="onFocus"
         />
-        <div class="symbol" v-bind:style="symbolStyle">
+        <div
+            class="symbol symbol-right"
+            v-bind:style="symbolStyle"
+            v-show="symbolPosition === 'right'"
+        >
             {{ symbol }}
         </div>
     </div>
@@ -45,7 +56,7 @@
 
 .input-symbol > .input {
     border: none;
-    border-radius: 6px 0px 0px 6px;
+    border-radius: 6px 6px 6px 6px;
     flex-shrink: 1;
     padding-right: 7px;
 }
@@ -71,6 +82,12 @@
     width: 34px;
 }
 
+.input-symbol > .symbol.symbol-left {
+    border-left: none;
+    border-radius: 6px 0px 0px 6px;
+    border-right: 1px solid #e4e8f0;
+}
+
 .input-symbol.color-white > .symbol {
     background-color: #fcfcfc;
 }
@@ -86,6 +103,10 @@ export const InputSymbol = {
         symbol: {
             type: String,
             required: true
+        },
+        symbolPosition: {
+            type: String,
+            default: "right"
         },
         value: {
             type: [String, Number],


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-design/issues/172 |
| Decisions | Add symbol position property to match input symbol design orientation for WYSIWYG components (https://zpl.io/bzrzn83) |
| Animated GIF | <img width="1146" alt="image" src="https://user-images.githubusercontent.com/24736423/97477944-2be99480-1948-11eb-9bd3-c2045ef21a16.png"> |
