### PR TITLE
#172 Button-icon: using primary icon when secundary is null

### DIFF
--- a/css/variables.scss
+++ b/css/variables.scss
@@ -11,4 +11,4 @@ $active-color: #eeeeee;
 $link-color: #4078c0;
 $link-hover-color: #4078c0;
 $label-color: #8d8d8d;
-$font-family: "lato", sans-serif;
+$font-family: "Lato", sans-serif;

--- a/css/variables.scss
+++ b/css/variables.scss
@@ -11,4 +11,4 @@ $active-color: #eeeeee;
 $link-color: #4078c0;
 $link-hover-color: #4078c0;
 $label-color: #8d8d8d;
-$font-family: Lato, sans-serif;
+$font-family: "lato", sans-serif;

--- a/vue/components/ui/molecules/button-icon-toggle/button-icon-toggle.vue
+++ b/vue/components/ui/molecules/button-icon-toggle/button-icon-toggle.vue
@@ -74,7 +74,10 @@ export const ButtonIconToggle = {
             return this.valueData ? this.colorSecondary : this.color;
         },
         iconComputed() {
-            return this.valueData ? this.iconSecondary || this.icon : this.icon;
+            return this.valueData ? this.iconSecondaryComputed : this.icon;
+        },
+        iconSecondaryComputed() {
+            return this.iconSecondary ? this.iconSecondary : this.icon;
         }
     },
     methods: {

--- a/vue/components/ui/molecules/button-icon-toggle/button-icon-toggle.vue
+++ b/vue/components/ui/molecules/button-icon-toggle/button-icon-toggle.vue
@@ -28,7 +28,7 @@ export const ButtonIconToggle = {
          */
         iconSecondary: {
             type: String,
-            default: "close"
+            default: null
         },
         /**
          * The color of the button when `value` is false.
@@ -74,7 +74,7 @@ export const ButtonIconToggle = {
             return this.valueData ? this.colorSecondary : this.color;
         },
         iconComputed() {
-            return this.valueData ? this.iconSecondary : this.icon;
+            return this.valueData ? this.iconSecondary || this.icon : this.icon;
         }
     },
     methods: {

--- a/vue/components/ui/molecules/button-icon-toggle/button-icon-toggle.vue
+++ b/vue/components/ui/molecules/button-icon-toggle/button-icon-toggle.vue
@@ -74,9 +74,9 @@ export const ButtonIconToggle = {
             return this.valueData ? this.colorSecondary : this.color;
         },
         iconComputed() {
-            return this.valueData ? this.iconSecondaryComputed : this.icon;
+            return this.valueData ? this._iconSecondary : this.icon;
         },
-        iconSecondaryComputed() {
+        _iconSecondary() {
             return this.iconSecondary ? this.iconSecondary : this.icon;
         }
     },


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-design/issues/172 |
| Decisions | Using secondary icon being when the first is not specified to avoid redundancy in common use cases such as: ` <button-icon-toggle v-bind:icon="'align-left'" v-bind:icon-secondary="'align-left'" />` |
| Animated GIF | ![aaaaaaa](https://user-images.githubusercontent.com/24736423/98700053-add9b480-236f-11eb-83da-88a66af29469.gif) |