### PR TITLE
Improve input color

### DIFF
--- a/vue/components/ui/molecules/input-color/input-color.stories.js
+++ b/vue/components/ui/molecules/input-color/input-color.stories.js
@@ -36,9 +36,7 @@ storiesOf("Molecules", module)
             <div>
                 <input-color
                     v-bind:value.sync="valueData"
-                    v-bind:input-props="{ disabled: disabled, variant: variant}"
-                    v-bind:disabled="disabled"
-                    v-bind:variant="variant" />
+                    v-bind:input-props="{ disabled: disabled, variant: variant}" />
                 <p>Color Value: {{ valueData }}</p>
             </div>
         `

--- a/vue/components/ui/molecules/input-color/input-color.vue
+++ b/vue/components/ui/molecules/input-color/input-color.vue
@@ -143,6 +143,7 @@ export const InputColor = {
         },
         onPickerClick() {
             if (this.inputProps && this.inputProps.disabled) return;
+            if (!this.hasValidColor) this.setValue("ffffff");
             this.showColorMenu();
         }
     }


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Input color should set color value to be "ffffff" in the native picker when color value is invalid in the user input to match intuitive view. This improves UX for WYSIWYG.  |
| Decisions | Add fix for setting white color when opening native color picker from invalid or null color. Add cleanup to storybook. |
| Animated GIF | ![Peek 2020-11-18 16-36](https://user-images.githubusercontent.com/24736423/99559281-8365a800-29bc-11eb-9f4d-c2abb48cdd7f.gif) |
