### PR TITLE
#172 Symbol slot for input-symbol

### DIFF
--- a/vue/components/ui/molecules/input-symbol/input-symbol.vue
+++ b/vue/components/ui/molecules/input-symbol/input-symbol.vue
@@ -5,7 +5,9 @@
             v-bind:style="symbolStyle"
             v-show="symbolPosition === 'left'"
         >
-            {{ symbol }}
+            <slot name="symbol">
+                {{ symbol }}
+            </slot>
         </div>
         <input-ripe
             v-bind:value.sync="valueData"
@@ -27,7 +29,9 @@
             v-bind:style="symbolStyle"
             v-show="symbolPosition === 'right'"
         >
-            {{ symbol }}
+            <slot name="symbol">
+                {{ symbol }}
+            </slot>
         </div>
     </div>
 </template>
@@ -102,7 +106,7 @@ export const InputSymbol = {
     props: {
         symbol: {
             type: String,
-            required: true
+            default: null
         },
         symbolPosition: {
             type: String,


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Need to use icons in input as seen in https://app.zeplin.io/project/5db732f9c02f1e8327288741/screen/5f8852cc4c8b5ca022bb3a9e (https://github.com/ripe-tech/ripe-design/issues/172) |
| Dependencies | -- |
| Decisions | • Can now use slot `symbol` to replace the symbol in `input-symbol`<br>• Prop `symbol` not set as required anymore |
| Screenshot | ![imagem](https://user-images.githubusercontent.com/22588915/99984075-8c7fbc00-2da4-11eb-915a-ad6c374d7d49.png) |
