### PR TITLE
Fixed storybook not being in fullscreen

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -5,9 +5,11 @@ import { install as RipeComponentsVue } from "../vue";
 
 import "./styles.css";
 
+export const parameters = {
+    layout: "fullscreen"
+};
+
 Vue.use(RipeComponentsVue);
 Vue.component("global-events", GlobalEvents);
 
 Vue.prototype.$bus = new Vue();
-
-export const parameters = { layout: "fullscreen" };

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -9,3 +9,5 @@ Vue.use(RipeComponentsVue);
 Vue.component("global-events", GlobalEvents);
 
 Vue.prototype.$bus = new Vue();
+
+export const parameters = { layout: "fullscreen" };


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Storybook width is not correct so it always has a scrollbar |
| Dependencies | -- |
| Decisions | Fixed storybook width thus removing the always present scrollbar.<br><br>This issue ocurred because in storybook 6.0 there was an added `padding `of `1rem`. To fix this we needed to add the `fullscreen` param in  `.storybook/preview.js`. (See https://storybook.js.org/docs/vue/configure/story-layout). For more information about this problem, check [this github issue](https://github.com/storybookjs/storybook/issues/12109). |
| Animated GIF | **Before fix:**<br>![storybook_before](https://user-images.githubusercontent.com/22588915/103999777-3d93b780-5195-11eb-8785-5dbbe5bd6ac2.gif)<br><br>**After fix:**<br>![storybook_after](https://user-images.githubusercontent.com/22588915/104000029-96fbe680-5195-11eb-8e25-d26d182efd7b.gif) |
