### PR TITLE
feat: button-group component

### DIFF
--- a/vue/components/ui/molecules/button-group/button-group.stories.js
+++ b/vue/components/ui/molecules/button-group/button-group.stories.js
@@ -12,7 +12,7 @@ storiesOf("Molecules", module)
                     { value: "2", label: "Item 2" },
                     { value: "3", label: "Item 3" },
                     { value: "4", label: "Item 4", color: "red" },
-                    { value: "5", label: "Item 5" }
+                    { value: "5", label: "Item 5", disabled: true }
                 ]
             },
             disabled: {

--- a/vue/components/ui/molecules/button-group/button-group.stories.js
+++ b/vue/components/ui/molecules/button-group/button-group.stories.js
@@ -8,10 +8,10 @@ storiesOf("Molecules", module)
             items: {
                 type: Array,
                 default: () => [
-                    { value: "1", label: "Item 1" },
+                    { value: "1", label: "Item 1", color: "blue" },
                     { value: "2", label: "Item 2" },
                     { value: "3", label: "Item 3" },
-                    { value: "4", label: "Item 4" },
+                    { value: "4", label: "Item 4", color: "red" },
                     { value: "5", label: "Item 5" }
                 ]
             },

--- a/vue/components/ui/molecules/button-group/button-group.stories.js
+++ b/vue/components/ui/molecules/button-group/button-group.stories.js
@@ -1,0 +1,33 @@
+import { storiesOf } from "@storybook/vue";
+import { withKnobs, boolean } from "@storybook/addon-knobs";
+
+storiesOf("Molecules", module)
+    .addDecorator(withKnobs)
+    .add("Button Group", () => ({
+        props: {
+            items: {
+                type: Array,
+                default: () => [
+                    { value: "1", label: "Item 1" },
+                    { value: "2", label: "Item 2" },
+                    { value: "3", label: "Item 3" },
+                    { value: "4", label: "Item 4" },
+                    { value: "5", label: "Item 5" }
+                ]
+            },
+            disabled: {
+                type: Boolean,
+                default: boolean("Disabled component", false)
+            }
+        },
+        template: `
+            <button-group
+                v-bind:items="items"
+                v-bind:disabled="disabled"
+            >
+                <template v-slot:button-3>
+                    Special Item 3
+                </template>
+            </button-group>
+        `
+    }));

--- a/vue/components/ui/molecules/button-group/button-group.stories.js
+++ b/vue/components/ui/molecules/button-group/button-group.stories.js
@@ -17,17 +17,28 @@ storiesOf("Molecules", module)
             },
             disabled: {
                 type: Boolean,
-                default: boolean("Disabled component", false)
+                default: boolean("Disabled", false)
+            }
+        },
+        data: function() {
+            return {
+                valueData: null
             }
         },
         template: `
+            <div>
             <button-group
                 v-bind:items="items"
                 v-bind:disabled="disabled"
+                    v-bind:value.sync="valueData"
             >
                 <template v-slot:button-3>
                     Special Item 3
                 </template>
             </button-group>
+                <div>
+                    Selected value: {{ valueData }}
+                </div>
+            </div>
         `
     }));

--- a/vue/components/ui/molecules/button-group/button-group.stories.js
+++ b/vue/components/ui/molecules/button-group/button-group.stories.js
@@ -23,19 +23,19 @@ storiesOf("Molecules", module)
         data: function() {
             return {
                 valueData: null
-            }
+            };
         },
         template: `
             <div>
-            <button-group
-                v-bind:items="items"
-                v-bind:disabled="disabled"
+                <button-group
+                    v-bind:items="items"
+                    v-bind:disabled="disabled"
                     v-bind:value.sync="valueData"
-            >
-                <template v-slot:button-3>
-                    Special Item 3
-                </template>
-            </button-group>
+                >
+                    <template v-slot:button-3>
+                        Special Item 3
+                    </template>
+                </button-group>
                 <div>
                     Selected value: {{ valueData }}
                 </div>

--- a/vue/components/ui/molecules/button-group/button-group.vue
+++ b/vue/components/ui/molecules/button-group/button-group.vue
@@ -1,0 +1,123 @@
+<template>
+    <div class="button-group">
+        <div
+            class="button-container"
+            v-for="item in items"
+            v-bind:key="item.value"
+            v-on:click="onClick($event, item)"
+        >
+            <slot v-bind:item="item" v-bind:selected="valueData === item.value">
+                <button-color
+                    class="button-color"
+                    v-bind:class="buttonClasses(item)"
+                    v-bind:disabled="disabled"
+                    v-bind:color="item.color"
+                >
+                    <slot
+                        v-bind:item="item"
+                        v-bind:selected="valueData === item.value"
+                        v-bind:name="`button-${item.value}`"
+                    >
+                        {{ item.label || item.value }}
+                    </slot>
+                </button-color>
+            </slot>
+        </div>
+    </div>
+</template>
+
+<style lang="scss" scoped>
+@import "css/colors.scss";
+
+.button-group > .button-container {
+    display: inline-block;
+}
+
+.button-group > .button-container > .button {
+    margin-right: 8px;
+}
+
+.button-group > .button-container:last-child > .button {
+    margin-right: 0px;
+}
+
+.button-group > .button-container > .button.selected {
+    background-color: $black;
+    border-color: $black;
+    color: $white;
+}
+</style>
+
+<script>
+/**
+ * A group of values that translate into buttons.
+ */
+export const ButtonGroup = {
+    name: "button-group",
+    props: {
+        /**
+         * The items representing each button, for example
+         * { value: "1", label: "Item 1", color: "blue" }
+         */
+        items: {
+            type: Array,
+            default: () => []
+        },
+        /**
+         * The currently selected value.
+         */
+        value: {
+            type: String,
+            default: null
+        },
+        /**
+         * Whether the buttons are disabled.
+         */
+        disabled: {
+            type: Boolean,
+            default: false
+        }
+    },
+    data: function() {
+        return {
+            valueData: this.value
+        };
+    },
+    watch: {
+        value(value) {
+            this.valueData = value;
+        },
+        valueData(value) {
+            /**
+             * Triggered when the selected value changes.
+             *
+             * @property {String} value The new selected value.
+             */
+            this.$emit("update:value", value);
+        }
+    },
+    methods: {
+        buttonClasses(item) {
+            const base = {
+                selected: this.valueData === item.value
+            };
+            base[item.value] = true;
+            return base;
+        },
+        onClick(event, item) {
+            if (this.disabled) return;
+
+            this.valueData = item.value;
+            /**
+             * Triggered when the user clicks a button.
+             *
+             * @property {Object} event The native event.
+             * @property {Object} item The item that was clicked.
+             */
+            this.$emit("click", event, item);
+        }
+    }
+};
+
+export default ButtonGroup;
+</script>

--- a/vue/components/ui/molecules/button-group/button-group.vue
+++ b/vue/components/ui/molecules/button-group/button-group.vue
@@ -10,7 +10,7 @@
                 <button-color
                     class="button-color"
                     v-bind:class="buttonClasses(item)"
-                    v-bind:disabled="disabled"
+                    v-bind:disabled="disabled || item.disabled"
                     v-bind:color="item.color"
                 >
                     <slot
@@ -56,8 +56,8 @@ export const ButtonGroup = {
     name: "button-group",
     props: {
         /**
-         * The items representing each button, for example
-         * { value: "1", label: "Item 1", color: "blue" }
+         * The items representing each button. Example:
+         * { value: "1", label: "Item 1", color: "blue", disabled: false }.
          */
         items: {
             type: Array,
@@ -105,7 +105,7 @@ export const ButtonGroup = {
             return base;
         },
         onClick(event, item) {
-            if (this.disabled) return;
+            if (this.disabled || item.disabled) return;
 
             this.valueData = item.value;
             /**

--- a/vue/components/ui/molecules/button-group/button-group.vue
+++ b/vue/components/ui/molecules/button-group/button-group.vue
@@ -98,10 +98,9 @@ export const ButtonGroup = {
     },
     methods: {
         buttonClasses(item) {
-            const base = {
-                selected: this.valueData === item.value
-            };
+            const base = {};
             base[item.value] = true;
+            base.selected = this.valueData === item.value;
             return base;
         },
         onClick(event, item) {

--- a/vue/components/ui/molecules/index.js
+++ b/vue/components/ui/molecules/index.js
@@ -4,6 +4,7 @@ import { AvatarName } from "./avatar-name/avatar-name.vue";
 import { AvatarNameEmail } from "./avatar-name-email/avatar-name-email.vue";
 import { BezierCurve } from "./bezier-curve/bezier-curve.vue";
 import { ButtonDropdown } from "./button-dropdown/button-dropdown.vue";
+import { ButtonGroup } from "./button-group/button-group.vue";
 import { ButtonIconAnimated } from "./button-icon-animated/button-icon-animated.vue";
 import { ButtonIconToggle } from "./button-icon-toggle/button-icon-toggle.vue";
 import { Carousel } from "./carousel/carousel.vue";
@@ -45,6 +46,7 @@ const install = Vue => {
     Vue.component("avatar-name-email", AvatarNameEmail);
     Vue.component("bezier-curve", BezierCurve);
     Vue.component("button-dropdown", ButtonDropdown);
+    Vue.component("button-group", ButtonGroup);
     Vue.component("button-icon-animated", ButtonIconAnimated);
     Vue.component("button-icon-toggle", ButtonIconToggle);
     Vue.component("carousel", Carousel);
@@ -87,6 +89,7 @@ export {
     AvatarNameEmail,
     BezierCurve,
     ButtonDropdown,
+    ButtonGroup,
     ButtonIconAnimated,
     ButtonIconToggle,
     Carousel,

--- a/vue/test/components/button-group/button-group.test.js
+++ b/vue/test/components/button-group/button-group.test.js
@@ -51,6 +51,26 @@ describe("ButtonGroup", () => {
         assert.strictEqual(disabledButtonItems.length, 0);
     });
 
+    it("should disable 3 buttons in the button group", async () => {
+        const component = base.getComponent("ButtonGroup", {
+            props: {
+                items: [
+                    { value: "1", label: "Item 1", disabled: true },
+                    { value: "2", label: "Item 2" },
+                    { value: "3", label: "Item 3", disabled: true },
+                    { value: "4", label: "Item 4", disabled: true },
+                    { value: "5", label: "Item 5" }
+                ]
+            }
+        });
+
+        const disabledButtonItems = component.findAll(".button-color.disabled");
+        assert.strictEqual(disabledButtonItems.length, 3);
+        assert.strictEqual(disabledButtonItems.at(0).text(), "Item 1");
+        assert.strictEqual(disabledButtonItems.at(1).text(), "Item 3");
+        assert.strictEqual(disabledButtonItems.at(2).text(), "Item 4");
+    });
+
     it("should select a button in the button group", async () => {
         const component = base.getComponent("ButtonGroup", {
             props: {

--- a/vue/test/components/button-group/button-group.test.js
+++ b/vue/test/components/button-group/button-group.test.js
@@ -1,0 +1,77 @@
+const assert = require("assert");
+const base = require("../../base");
+
+describe("ButtonGroup", () => {
+    it("should initialize the button group", () => {
+        const component = base.getComponent("ButtonGroup", {
+            props: {
+                items: [
+                    { value: "1", label: "Item 1" },
+                    { value: "2", label: "Item 2" },
+                    { value: "3", label: "Item 3" },
+                    { value: "4", label: "Item 4" },
+                    { value: "5", label: "Item 5" }
+                ]
+            }
+        });
+
+        const buttonItems = component.findAll(".button-color");
+        assert.strictEqual(buttonItems.length, 5);
+        assert.strictEqual(buttonItems.at(0).text(), "Item 1");
+        assert.strictEqual(buttonItems.at(1).text(), "Item 2");
+        assert.strictEqual(buttonItems.at(2).text(), "Item 3");
+        assert.strictEqual(buttonItems.at(3).text(), "Item 4");
+        assert.strictEqual(buttonItems.at(4).text(), "Item 5");
+    });
+
+    it("should disable all buttons in the button group", async () => {
+        const component = base.getComponent("ButtonGroup", {
+            props: {
+                items: [
+                    { value: "1", label: "Item 1" },
+                    { value: "2", label: "Item 2" },
+                    { value: "3", label: "Item 3" },
+                    { value: "4", label: "Item 4" },
+                    { value: "5", label: "Item 5" }
+                ],
+                disabled: true
+            }
+        });
+
+        let disabledButtonItems = component.findAll(".button-color.disabled");
+        assert.strictEqual(disabledButtonItems.length, 5);
+        assert.strictEqual(disabledButtonItems.at(0).text(), "Item 1");
+        assert.strictEqual(disabledButtonItems.at(1).text(), "Item 2");
+        assert.strictEqual(disabledButtonItems.at(2).text(), "Item 3");
+        assert.strictEqual(disabledButtonItems.at(3).text(), "Item 4");
+        assert.strictEqual(disabledButtonItems.at(4).text(), "Item 5");
+
+        await component.setProps({ disabled: false });
+        disabledButtonItems = component.findAll(".button-color.disabled");
+        assert.strictEqual(disabledButtonItems.length, 0);
+    });
+
+    it("should select a button in the button group", async () => {
+        const component = base.getComponent("ButtonGroup", {
+            props: {
+                items: [
+                    { value: "1", label: "Item 1" },
+                    { value: "2", label: "Item 2" },
+                    { value: "3", label: "Item 3" },
+                    { value: "4", label: "Item 4" },
+                    { value: "5", label: "Item 5" }
+                ],
+                value: "3"
+            }
+        });
+
+        let selectedButton = component.find(".button-color.selected");
+        assert.strictEqual(selectedButton.exists(), true);
+        assert.strictEqual(selectedButton.text(), "Item 3");
+
+        await component.setProps({ value: "4" });
+        selectedButton = component.find(".button-color.selected");
+        assert.strictEqual(selectedButton.exists(), true);
+        assert.strictEqual(selectedButton.text(), "Item 4");
+    });
+});


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Originated from https://github.com/ripe-tech/ripe-twitch/issues/7 (payment buttons) |
| Dependencies | -- |
| Decisions | Similar to ripe-white [`button-group`](https://github.com/ripe-tech/ripe-white/blob/4fa823a3fc0658eacbfaa3247caee575f2c283c6/vue/components/molecules/button-group/button-group.vue). Only added an additional slot to possibly modify the interior of the button, as well as passing the color prop to the `button-color`.  |
| Link | https://ripe-components-vue-git-ms-7-buttongroupcomponent.platforme.vercel.app/?path=/story/molecules--button-group | 
| Animated GIF | ![button-group](https://user-images.githubusercontent.com/25725586/105382814-60e44b00-5c08-11eb-98e6-12210696fcb3.gif) |
