### PR TITLE
Fix context item interation

### DIFF
--- a/vue/components/ui/atoms/icon/icon.vue
+++ b/vue/components/ui/atoms/icon/icon.vue
@@ -88,7 +88,9 @@ export const Icon = {
                     // icon as part of its source
                     const iconContexts =
                         this.$root && this.$root.$iconContexts ? this.$root.$iconContexts : [];
-                    const iconContext = iconContexts.find(c => c.keys().includes(this.icon));
+                    const iconContext = iconContexts.find(c =>
+                        c.keys().find(key => key === `./${this.icon}.svg`)
+                    );
 
                     // if there is a custom context defined at the root that
                     // contains the item, then uses it


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Small fix iteration through the `iconContexts` to fix error when loading external icon modules e.g. when loading ripe-twitch icons in ripe-twitch-ui. <br /> ![image](https://user-images.githubusercontent.com/24736423/105529703-a83d0b00-5cde-11eb-8090-d2f8d6636c5e.png) |
