### PR TITLE
Fix select-ripe value selection error in a mobile device

### DIFF
--- a/vue/components/ui/molecules/select/select.vue
+++ b/vue/components/ui/molecules/select/select.vue
@@ -5,7 +5,7 @@
             class="dropdown-select"
             v-bind:value="value"
             v-if="isDevice()"
-            v-on:change="onSelectChange($event.target.value)"
+            v-on:change="event => onSelectChange(event.target.value)"
         >
             <option
                 v-bind:value="options.value"

--- a/vue/components/ui/molecules/select/select.vue
+++ b/vue/components/ui/molecules/select/select.vue
@@ -5,7 +5,7 @@
             class="dropdown-select"
             v-bind:value="value"
             v-if="isDevice()"
-            v-on:change="() => onSelectChange($event.target.value)"
+            v-on:change="onSelectChange($event.target.value)"
         >
             <option
                 v-bind:value="options.value"


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Error when selecting a value in a mobile device |
| Dependencies | -- |
| Decisions | Fixed error when trying to select a value in a mobile device |
| Screenshot | **Error screenshot:**<br>![imagem](https://user-images.githubusercontent.com/22588915/106931121-27363880-670e-11eb-8c3b-35c3be69f035.png) |
