### PR TITLE
Fix storybook component search

### DIFF
--- a/vue/components/ui/animations/animation-visualizer/animation-visualizer.stories.js
+++ b/vue/components/ui/animations/animation-visualizer/animation-visualizer.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, select, text } from "@storybook/addon-knobs";
 
-storiesOf("Animations", module)
+storiesOf("Components/Animations/Animation Visualizer", module)
     .addDecorator(withKnobs)
     .add("Animation Visualizer", () => ({
         props: {

--- a/vue/components/ui/animations/animations-list.stories.js
+++ b/vue/components/ui/animations/animations-list.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, text } from "@storybook/addon-knobs";
 
-storiesOf("Animations", module)
+storiesOf("Components/Animations/Animations List", module)
     .addDecorator(withKnobs)
     .add("Animations List", () => ({
         props: {

--- a/vue/components/ui/atoms/attachments/attachments.stories.js
+++ b/vue/components/ui/atoms/attachments/attachments.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, number } from "@storybook/addon-knobs";
 
-storiesOf("Atoms", module)
+storiesOf("Components/Atoms/Attachments", module)
     .addDecorator(withKnobs)
     .add("Attachments", () => ({
         props: {

--- a/vue/components/ui/atoms/avatar/avatar.stories.js
+++ b/vue/components/ui/atoms/avatar/avatar.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, text, select, boolean } from "@storybook/addon-knobs";
 
-storiesOf("Atoms", module)
+storiesOf("Components/Atoms/Avatar", module)
     .addDecorator(withKnobs)
     .add("Avatar", () => ({
         props: {

--- a/vue/components/ui/atoms/breadcrumbs/breadcrumbs.stories.js
+++ b/vue/components/ui/atoms/breadcrumbs/breadcrumbs.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, text, number } from "@storybook/addon-knobs";
 
-storiesOf("Atoms", module)
+storiesOf("Components/Atoms/Breadcrumbs", module)
     .addDecorator(withKnobs)
     .add("Breadcrumbs", () => ({
         props: {

--- a/vue/components/ui/atoms/bubble/bubble.stories.js
+++ b/vue/components/ui/atoms/bubble/bubble.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, boolean, number } from "@storybook/addon-knobs";
 
-storiesOf("Atoms", module)
+storiesOf("Components/Atoms/Bubble", module)
     .addDecorator(withKnobs)
     .add("Bubble", () => ({
         props: {

--- a/vue/components/ui/atoms/button-color/button-color.stories.js
+++ b/vue/components/ui/atoms/button-color/button-color.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, select, boolean, number } from "@storybook/addon-knobs";
 
-storiesOf("Atoms", module)
+storiesOf("Components/Atoms/Button Color", module)
     .addDecorator(withKnobs)
     .add("Button Color", () => ({
         props: {

--- a/vue/components/ui/atoms/button-icon/button-icon.stories.js
+++ b/vue/components/ui/atoms/button-icon/button-icon.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, text, number, select, boolean } from "@storybook/addon-knobs";
 
-storiesOf("Atoms", module)
+storiesOf("Components/Atoms/Button Icon", module)
     .addDecorator(withKnobs)
     .add("Button Icon", () => ({
         props: {

--- a/vue/components/ui/atoms/button-platforme/button-platforme.stories.js
+++ b/vue/components/ui/atoms/button-platforme/button-platforme.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, text, boolean } from "@storybook/addon-knobs";
 
-storiesOf("Atoms", module)
+storiesOf("Components/Atoms/Button Platforme", module)
     .addDecorator(withKnobs)
     .add("Button Platforme", () => ({
         props: {

--- a/vue/components/ui/atoms/checkbox/checkbox.stories.js
+++ b/vue/components/ui/atoms/checkbox/checkbox.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, boolean, text, select, number } from "@storybook/addon-knobs";
 
-storiesOf("Atoms", module)
+storiesOf("Components/Atoms/Checkbox", module)
     .addDecorator(withKnobs)
     .add("Checkbox", () => ({
         props: {

--- a/vue/components/ui/atoms/checkmark/checkmark.stories.js
+++ b/vue/components/ui/atoms/checkmark/checkmark.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, boolean, number } from "@storybook/addon-knobs";
 
-storiesOf("Atoms", module)
+storiesOf("Components/Atoms/Checkmark", module)
     .addDecorator(withKnobs)
     .add("Checkmark", () => ({
         props: {

--- a/vue/components/ui/atoms/container/container.stories.js
+++ b/vue/components/ui/atoms/container/container.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, text, select } from "@storybook/addon-knobs";
 
-storiesOf("Atoms", module)
+storiesOf("Components/Atoms/Container", module)
     .addDecorator(withKnobs)
     .add("Container", () => ({
         props: {

--- a/vue/components/ui/atoms/dropdown/dropdown.stories.js
+++ b/vue/components/ui/atoms/dropdown/dropdown.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, boolean, select, text } from "@storybook/addon-knobs";
 
-storiesOf("Atoms", module)
+storiesOf("Components/Atoms/Dropdown", module)
     .addDecorator(withKnobs)
     .add("Dropdown", () => ({
         props: {

--- a/vue/components/ui/atoms/icon/icon.stories.js
+++ b/vue/components/ui/atoms/icon/icon.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, text, number, color } from "@storybook/addon-knobs";
 
-storiesOf("Atoms", module)
+storiesOf("Components/Atoms/Icon", module)
     .addDecorator(withKnobs)
     .add("Icon", () => ({
         props: {

--- a/vue/components/ui/atoms/image/image.stories.js
+++ b/vue/components/ui/atoms/image/image.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, text } from "@storybook/addon-knobs";
 
-storiesOf("Atoms", module)
+storiesOf("Components/Atoms/Image", module)
     .addDecorator(withKnobs)
     .add("Image", () => ({
         props: {

--- a/vue/components/ui/atoms/input/input.stories.js
+++ b/vue/components/ui/atoms/input/input.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, text, boolean, number, select } from "@storybook/addon-knobs";
 
-storiesOf("Atoms", module)
+storiesOf("Components/Atoms/Input", module)
     .addDecorator(withKnobs)
     .add("Input", () => ({
         props: {

--- a/vue/components/ui/atoms/label/label.stories.js
+++ b/vue/components/ui/atoms/label/label.stories.js
@@ -1,6 +1,6 @@
 import { storiesOf } from "@storybook/vue";
 
-storiesOf("Atoms", module).add("Label", () => ({
+storiesOf("Components/Atoms/Label", module).add("Label", () => ({
     template: `
         <div>
             <div><label-ripe v-bind:text='"This is a normal label"'></label-ripe></div>

--- a/vue/components/ui/atoms/link/link.stories.js
+++ b/vue/components/ui/atoms/link/link.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, boolean, select } from "@storybook/addon-knobs";
 
-storiesOf("Atoms", module)
+storiesOf("Components/Atoms/Link", module)
     .addDecorator(withKnobs)
     .add("Link", () => ({
         props: {

--- a/vue/components/ui/atoms/loader/loader.stories.js
+++ b/vue/components/ui/atoms/loader/loader.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, color, number } from "@storybook/addon-knobs";
 
-storiesOf("Atoms", module)
+storiesOf("Components/Atoms/Loader", module)
     .addDecorator(withKnobs)
     .add("Loader Ball Pulse", () => ({
         props: {

--- a/vue/components/ui/atoms/overlay/overlay.stories.js
+++ b/vue/components/ui/atoms/overlay/overlay.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, boolean } from "@storybook/addon-knobs";
 
-storiesOf("Atoms", module)
+storiesOf("Components/Atoms/Overlay", module)
     .addDecorator(withKnobs)
     .add("Overlay", () => ({
         props: {

--- a/vue/components/ui/atoms/padded/padded.stories.js
+++ b/vue/components/ui/atoms/padded/padded.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs } from "@storybook/addon-knobs";
 
-storiesOf("Atoms", module)
+storiesOf("Components/Atoms/Padded", module)
     .addDecorator(withKnobs)
     .add("Padded", () => ({
         template: "<padded>This is padded content</padded>"

--- a/vue/components/ui/atoms/paragraph/paragraph.stories.js
+++ b/vue/components/ui/atoms/paragraph/paragraph.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, text } from "@storybook/addon-knobs";
 
-storiesOf("Atoms", module)
+storiesOf("Components/Atoms/Paragraph", module)
     .addDecorator(withKnobs)
     .add("Paragraph", () => ({
         props: {

--- a/vue/components/ui/atoms/radio/radio.stories.js
+++ b/vue/components/ui/atoms/radio/radio.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, boolean, text, select } from "@storybook/addon-knobs";
 
-storiesOf("Atoms", module)
+storiesOf("Components/Atoms/Radio", module)
     .addDecorator(withKnobs)
     .add("Radio", () => ({
         props: {

--- a/vue/components/ui/atoms/reaction/reaction.stories.js
+++ b/vue/components/ui/atoms/reaction/reaction.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, select, text, number, boolean } from "@storybook/addon-knobs";
 
-storiesOf("Atoms", module)
+storiesOf("Components/Atoms/Reaction", module)
     .addDecorator(withKnobs)
     .add("Reaction", () => ({
         props: {

--- a/vue/components/ui/atoms/rich-textarea/rich-textarea.stories.js
+++ b/vue/components/ui/atoms/rich-textarea/rich-textarea.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, text, boolean, select } from "@storybook/addon-knobs";
 
-storiesOf("Atoms", module)
+storiesOf("Components/Atoms/Rich Textarea", module)
     .addDecorator(withKnobs)
     .add("Rich Textarea", () => ({
         props: {

--- a/vue/components/ui/atoms/side/side.stories.js
+++ b/vue/components/ui/atoms/side/side.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, boolean, number, select } from "@storybook/addon-knobs";
 
-storiesOf("Atoms", module)
+storiesOf("Components/Atoms/Side", module)
     .addDecorator(withKnobs)
     .add("Side", () => ({
         props: {

--- a/vue/components/ui/atoms/switcher/switcher.stories.js
+++ b/vue/components/ui/atoms/switcher/switcher.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, boolean } from "@storybook/addon-knobs";
 
-storiesOf("Atoms", module)
+storiesOf("Components/Atoms/Switcher", module)
     .addDecorator(withKnobs)
     .add("Switcher", () => ({
         props: {

--- a/vue/components/ui/atoms/tag/tag.stories.js
+++ b/vue/components/ui/atoms/tag/tag.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, text, select, boolean } from "@storybook/addon-knobs";
 
-storiesOf("Atoms", module)
+storiesOf("Components/Atoms/Tag", module)
     .addDecorator(withKnobs)
     .add("Tag", () => ({
         props: {

--- a/vue/components/ui/atoms/textarea/textarea.stories.js
+++ b/vue/components/ui/atoms/textarea/textarea.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, text, boolean, number, select } from "@storybook/addon-knobs";
 
-storiesOf("Atoms", module)
+storiesOf("Components/Atoms/Textarea", module)
     .addDecorator(withKnobs)
     .add("Textarea", () => ({
         props: {

--- a/vue/components/ui/atoms/title/title.stories.js
+++ b/vue/components/ui/atoms/title/title.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, text, select } from "@storybook/addon-knobs";
 
-storiesOf("Atoms", module)
+storiesOf("Components/Atoms/Title", module)
     .addDecorator(withKnobs)
     .add("Title", () => ({
         props: {

--- a/vue/components/ui/molecules/avatar-name-email/avatar-name-email.stories.js
+++ b/vue/components/ui/molecules/avatar-name-email/avatar-name-email.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, text } from "@storybook/addon-knobs";
 
-storiesOf("Molecules", module)
+storiesOf("Components/Molecules/Avatar Name Email", module)
     .addDecorator(withKnobs)
     .add("Avatar Name Email", () => ({
         props: {

--- a/vue/components/ui/molecules/avatar-name/avatar-name.stories.js
+++ b/vue/components/ui/molecules/avatar-name/avatar-name.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, text } from "@storybook/addon-knobs";
 
-storiesOf("Molecules", module)
+storiesOf("Components/Molecules/Avatar Name", module)
     .addDecorator(withKnobs)
     .add("Avatar Name", () => ({
         props: {

--- a/vue/components/ui/molecules/bezier-curve/bezier-curve.stories.js
+++ b/vue/components/ui/molecules/bezier-curve/bezier-curve.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, number, boolean, text } from "@storybook/addon-knobs";
 
-storiesOf("Molecules", module)
+storiesOf("Components/Molecules/Bezier Curve", module)
     .addDecorator(withKnobs)
     .add("Bezier Curve", () => ({
         props: {

--- a/vue/components/ui/molecules/button-dropdown/button-dropdown.stories.js
+++ b/vue/components/ui/molecules/button-dropdown/button-dropdown.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, select, text } from "@storybook/addon-knobs";
 
-storiesOf("Molecules", module)
+storiesOf("Components/Molecules/Button Dropdown", module)
     .addDecorator(withKnobs)
     .add("Button Dropdown", () => ({
         props: {

--- a/vue/components/ui/molecules/button-icon-animated/button-icon-animated.stories.js
+++ b/vue/components/ui/molecules/button-icon-animated/button-icon-animated.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, number, select, boolean } from "@storybook/addon-knobs";
 
-storiesOf("Molecules", module)
+storiesOf("Components/Molecules/Button Icon Animated", module)
     .addDecorator(withKnobs)
     .add("Button Icon Animated", () => ({
         props: {

--- a/vue/components/ui/molecules/button-icon-toggle/button-icon-toggle.stories.js
+++ b/vue/components/ui/molecules/button-icon-toggle/button-icon-toggle.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, select, boolean } from "@storybook/addon-knobs";
 
-storiesOf("Molecules", module)
+storiesOf("Components/Molecules/Button Icon Toggle", module)
     .addDecorator(withKnobs)
     .add("Button Icon Toggle", () => ({
         props: {

--- a/vue/components/ui/molecules/carousel/carousel.stories.js
+++ b/vue/components/ui/molecules/carousel/carousel.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, number, boolean, color } from "@storybook/addon-knobs";
 
-storiesOf("Molecules", module)
+storiesOf("Components/Molecules/Carousel", module)
     .addDecorator(withKnobs)
     .add("Carousel", () => ({
         props: {

--- a/vue/components/ui/molecules/chat-message/chat-message.stories.js
+++ b/vue/components/ui/molecules/chat-message/chat-message.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, text, number } from "@storybook/addon-knobs";
 
-storiesOf("Molecules", module)
+storiesOf("Components/Molecules/Chat Message", module)
     .addDecorator(withKnobs)
     .add("Chat Message", () => ({
         props: {

--- a/vue/components/ui/molecules/checkbox-group/checkbox-group.stories.js
+++ b/vue/components/ui/molecules/checkbox-group/checkbox-group.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, boolean } from "@storybook/addon-knobs";
 
-storiesOf("Molecules", module)
+storiesOf("Components/Molecules/Checkbox Group", module)
     .addDecorator(withKnobs)
     .add("Checkbox Group", () => ({
         props: {

--- a/vue/components/ui/molecules/container-menu/container-menu.stories.js
+++ b/vue/components/ui/molecules/container-menu/container-menu.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, text, select, number, boolean } from "@storybook/addon-knobs";
 
-storiesOf("Molecules", module)
+storiesOf("Components/Molecules/Container Menu", module)
     .addDecorator(withKnobs)
     .add("Container Menu", () => ({
         props: {

--- a/vue/components/ui/molecules/filter/filter.stories.js
+++ b/vue/components/ui/molecules/filter/filter.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, boolean } from "@storybook/addon-knobs";
 
-storiesOf("Molecules", module)
+storiesOf("Components/Molecules/Filter", module)
     .addDecorator(withKnobs)
     .add("Filter", () => ({
         props: {

--- a/vue/components/ui/molecules/footer/footer.stories.js
+++ b/vue/components/ui/molecules/footer/footer.stories.js
@@ -1,5 +1,5 @@
 import { storiesOf } from "@storybook/vue";
 
-storiesOf("Molecules", module).add("Footer", () => ({
+storiesOf("Components/Molecules/Footer", module).add("Footer", () => ({
     template: "<div><global></global><footer-ripe></footer-ripe></div>"
 }));

--- a/vue/components/ui/molecules/form-input/form-input.stories.js
+++ b/vue/components/ui/molecules/form-input/form-input.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, text, number, select } from "@storybook/addon-knobs";
 
-storiesOf("Molecules", module)
+storiesOf("Components/Molecules/Form Input", module)
     .addDecorator(withKnobs)
     .add("Form Input", () => ({
         props: {

--- a/vue/components/ui/molecules/input-color/input-color.stories.js
+++ b/vue/components/ui/molecules/input-color/input-color.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, text, select, boolean } from "@storybook/addon-knobs";
 
-storiesOf("Molecules", module)
+storiesOf("Components/Molecules/Input Color", module)
     .addDecorator(withKnobs)
     .add("Input Color", () => ({
         props: {

--- a/vue/components/ui/molecules/input-currency/input-currency.stories.js
+++ b/vue/components/ui/molecules/input-currency/input-currency.stories.js
@@ -3,7 +3,7 @@ import { withKnobs, text, boolean, number, select } from "@storybook/addon-knobs
 
 import rates from "./assets/rates_example.json";
 
-storiesOf("Molecules", module)
+storiesOf("Components/Molecules/Input Currency", module)
     .addDecorator(withKnobs)
     .add("Input Currency", () => ({
         props: {

--- a/vue/components/ui/molecules/input-image/input-image.stories.js
+++ b/vue/components/ui/molecules/input-image/input-image.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, boolean } from "@storybook/addon-knobs";
 
-storiesOf("Molecules", module)
+storiesOf("Components/Molecules/Input Image", module)
     .addDecorator(withKnobs)
     .add("Input Image", () => ({
         props: {

--- a/vue/components/ui/molecules/input-slider/input-slider.stories.js
+++ b/vue/components/ui/molecules/input-slider/input-slider.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, boolean, number, text, select } from "@storybook/addon-knobs";
 
-storiesOf("Molecules", module)
+storiesOf("Components/Molecules/Input Slider", module)
     .addDecorator(withKnobs)
     .add("Input Slider", () => ({
         props: {

--- a/vue/components/ui/molecules/input-symbol/input-symbol.stories.js
+++ b/vue/components/ui/molecules/input-symbol/input-symbol.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, text, boolean, number, select } from "@storybook/addon-knobs";
 
-storiesOf("Molecules", module)
+storiesOf("Components/Molecules/Input Symbol", module)
     .addDecorator(withKnobs)
     .add("Input Symbol", () => ({
         props: {

--- a/vue/components/ui/molecules/lightbox/lightbox.stories.js
+++ b/vue/components/ui/molecules/lightbox/lightbox.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, boolean } from "@storybook/addon-knobs";
 
-storiesOf("Molecules", module)
+storiesOf("Components/Molecules/Lightbox", module)
     .addDecorator(withKnobs)
     .add("Lightbox", () => ({
         props: {

--- a/vue/components/ui/molecules/lineup/lineup.stories.js
+++ b/vue/components/ui/molecules/lineup/lineup.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, number, select } from "@storybook/addon-knobs";
 
-storiesOf("Molecules", module)
+storiesOf("Components/Molecules/Lineup", module)
     .addDecorator(withKnobs)
     .add("Lineup", () => ({
         props: {

--- a/vue/components/ui/molecules/modal/modal.stories.js
+++ b/vue/components/ui/molecules/modal/modal.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, text, boolean, select } from "@storybook/addon-knobs";
 
-storiesOf("Molecules", module)
+storiesOf("Components/Molecules/Modal", module)
     .addDecorator(withKnobs)
     .add("Modal", () => ({
         props: {

--- a/vue/components/ui/molecules/notification/notification.stories.js
+++ b/vue/components/ui/molecules/notification/notification.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, text, boolean, color, select, number } from "@storybook/addon-knobs";
 
-storiesOf("Molecules", module)
+storiesOf("Components/Molecules/Notification", module)
     .addDecorator(withKnobs)
     .add("Notification", () => ({
         props: {

--- a/vue/components/ui/molecules/progress-bar/progress-bar.stories.js
+++ b/vue/components/ui/molecules/progress-bar/progress-bar.stories.js
@@ -6,7 +6,7 @@ const style = {
     "max-width": "200px"
 };
 
-storiesOf("Molecules", module)
+storiesOf("Components/Molecules/Progress Bar", module)
     .addDecorator(withKnobs)
     .add("Progress Bar", () => ({
         props: {

--- a/vue/components/ui/molecules/progress-list-item/progress-list-item.stories.js
+++ b/vue/components/ui/molecules/progress-list-item/progress-list-item.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, text, boolean, number } from "@storybook/addon-knobs";
 
-storiesOf("Molecules", module)
+storiesOf("Components/Molecules/Progress List Item", module)
     .addDecorator(withKnobs)
     .add("Progress List Item", () => ({
         props: {

--- a/vue/components/ui/molecules/progress-list/progress-list.stories.js
+++ b/vue/components/ui/molecules/progress-list/progress-list.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, text } from "@storybook/addon-knobs";
 
-storiesOf("Molecules", module)
+storiesOf("Components/Molecules/Progress List", module)
     .addDecorator(withKnobs)
     .add("Progress List", () => ({
         props: {

--- a/vue/components/ui/molecules/radio-group/radio-group.stories.js
+++ b/vue/components/ui/molecules/radio-group/radio-group.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, boolean, select } from "@storybook/addon-knobs";
 
-storiesOf("Molecules", module)
+storiesOf("Components/Molecules/Radio Group", module)
     .addDecorator(withKnobs)
     .add("Radio Group", () => ({
         props: {

--- a/vue/components/ui/molecules/search/search.stories.js
+++ b/vue/components/ui/molecules/search/search.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, boolean, number, select } from "@storybook/addon-knobs";
 
-storiesOf("Molecules", module)
+storiesOf("Components/Molecules/Search", module)
     .addDecorator(withKnobs)
     .add("Search", () => ({
         props: {

--- a/vue/components/ui/molecules/select-checkboxes/select-checkboxes.stories.js
+++ b/vue/components/ui/molecules/select-checkboxes/select-checkboxes.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, text } from "@storybook/addon-knobs";
 
-storiesOf("Molecules", module)
+storiesOf("Components/Molecules/Select Checkboxes", module)
     .addDecorator(withKnobs)
     .add("Select Checkboxes", () => ({
         props: {

--- a/vue/components/ui/molecules/select-list/select-list.stories.js
+++ b/vue/components/ui/molecules/select-list/select-list.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, number, boolean } from "@storybook/addon-knobs";
 
-storiesOf("Molecules", module)
+storiesOf("Components/Molecules/Select List", module)
     .addDecorator(withKnobs)
     .add("Select List", () => ({
         props: {

--- a/vue/components/ui/molecules/select/select.stories.js
+++ b/vue/components/ui/molecules/select/select.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, text, number, boolean, select } from "@storybook/addon-knobs";
 
-storiesOf("Molecules", module)
+storiesOf("Components/Molecules/Select", module)
     .addDecorator(withKnobs)
     .add("Select", () => ({
         props: {

--- a/vue/components/ui/molecules/slider/slider.stories.js
+++ b/vue/components/ui/molecules/slider/slider.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, boolean, number } from "@storybook/addon-knobs";
 
-storiesOf("Molecules", module)
+storiesOf("Components/Molecules/Slider", module)
     .addDecorator(withKnobs)
     .add("Slider", () => ({
         props: {

--- a/vue/components/ui/molecules/steps/steps.stories.js
+++ b/vue/components/ui/molecules/steps/steps.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, number, boolean } from "@storybook/addon-knobs";
 
-storiesOf("Molecules", module)
+storiesOf("Components/Molecules/Steps", module)
     .addDecorator(withKnobs)
     .add("Steps", () => ({
         props: {

--- a/vue/components/ui/molecules/table-expandable/table-expandable.stories.js
+++ b/vue/components/ui/molecules/table-expandable/table-expandable.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, select } from "@storybook/addon-knobs";
 
-storiesOf("Molecules", module)
+storiesOf("Components/Molecules/Table Expandable", module)
     .addDecorator(withKnobs)
     .add("Table Expandable", () => ({
         props: {

--- a/vue/components/ui/molecules/table/table.custom.stories.js
+++ b/vue/components/ui/molecules/table/table.custom.stories.js
@@ -1,6 +1,6 @@
 import { storiesOf } from "@storybook/vue";
 
-storiesOf("Molecules", module).add("Table Custom", () => ({
+storiesOf("Components/Molecules/Table Custom", module).add("Table Custom", () => ({
     props: {
         mockColumns: {
             type: Array,

--- a/vue/components/ui/molecules/table/table.stories.js
+++ b/vue/components/ui/molecules/table/table.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, select, boolean, number } from "@storybook/addon-knobs";
 
-storiesOf("Molecules", module)
+storiesOf("Components/Molecules/Table", module)
     .addDecorator(withKnobs)
     .add("Table", () => ({
         props: {

--- a/vue/components/ui/molecules/tabs/tabs.stories.js
+++ b/vue/components/ui/molecules/tabs/tabs.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, number, select } from "@storybook/addon-knobs";
 
-storiesOf("Molecules", module)
+storiesOf("Components/Molecules/Tabs", module)
     .addDecorator(withKnobs)
     .add("Tabs", () => ({
         props: {

--- a/vue/components/ui/molecules/transfer-list/transfer-list.stories.js
+++ b/vue/components/ui/molecules/transfer-list/transfer-list.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, boolean, number } from "@storybook/addon-knobs";
 
-storiesOf("Molecules", module)
+storiesOf("Components/Molecules/Transfer List", module)
     .addDecorator(withKnobs)
     .add("Transfer List", () => ({
         props: {

--- a/vue/components/ui/molecules/upload-area/upload-area.stories.js
+++ b/vue/components/ui/molecules/upload-area/upload-area.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, text, select } from "@storybook/addon-knobs";
 
-storiesOf("Molecules", module)
+storiesOf("Components/Molecules/Upload Area", module)
     .addDecorator(withKnobs)
     .add("Upload Area", () => ({
         props: {

--- a/vue/components/ui/organisms/chat/chat.stories.js
+++ b/vue/components/ui/organisms/chat/chat.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, text } from "@storybook/addon-knobs";
 
-storiesOf("Organisms", module)
+storiesOf("Components/Organisms/Chat", module)
     .addDecorator(withKnobs)
     .add("Chat", () => ({
         props: {

--- a/vue/components/ui/organisms/details/details.stories.js
+++ b/vue/components/ui/organisms/details/details.stories.js
@@ -3,7 +3,7 @@ import { withKnobs, text, number, boolean } from "@storybook/addon-knobs";
 
 import "./details.stories.css";
 
-storiesOf("Organisms", module)
+storiesOf("Components/Organisms/Details", module)
     .addDecorator(withKnobs)
     .add("Details", () => ({
         props: {

--- a/vue/components/ui/organisms/entity-list/entity-list.stories.js
+++ b/vue/components/ui/organisms/entity-list/entity-list.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, text, boolean } from "@storybook/addon-knobs";
 
-storiesOf("Organisms", module)
+storiesOf("Components/Organisms/Entity List", module)
     .addDecorator(withKnobs)
     .add("Entity List", () => ({
         props: {

--- a/vue/components/ui/organisms/header/header.stories.js
+++ b/vue/components/ui/organisms/header/header.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, text, boolean, number, select } from "@storybook/addon-knobs";
 
-storiesOf("Organisms", module)
+storiesOf("Components/Organisms/Header", module)
     .addDecorator(withKnobs)
     .add("Header", () => ({
         props: {

--- a/vue/components/ui/organisms/listing/listing.stories.js
+++ b/vue/components/ui/organisms/listing/listing.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, text, select, boolean } from "@storybook/addon-knobs";
 
-storiesOf("Organisms", module)
+storiesOf("Components/Organisms/Listing", module)
     .addDecorator(withKnobs)
     .add("Listing", () => ({
         props: {

--- a/vue/components/ui/organisms/table-menu/table-menu.stories.js
+++ b/vue/components/ui/organisms/table-menu/table-menu.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, select, boolean, number, color, text } from "@storybook/addon-knobs";
 
-storiesOf("Organisms", module)
+storiesOf("Components/Organisms/Table Menu", module)
     .addDecorator(withKnobs)
     .add("Table Menu", () => ({
         props: {

--- a/vue/components/ui/templates/error-part/error-part.stories.js
+++ b/vue/components/ui/templates/error-part/error-part.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, text, boolean, number } from "@storybook/addon-knobs";
 
-storiesOf("Templates", module)
+storiesOf("Components/Templates/Error", module)
     .addDecorator(withKnobs)
     .add("Error", () => ({
         props: {

--- a/vue/components/ui/templates/home-color-part/home-color-part.stories.js
+++ b/vue/components/ui/templates/home-color-part/home-color-part.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, text, select } from "@storybook/addon-knobs";
 
-storiesOf("Templates", module)
+storiesOf("Components/Templates/Home Color", module)
     .addDecorator(withKnobs)
     .add("Home Color", () => ({
         props: {

--- a/vue/components/ui/templates/home-part/home-part.stories.js
+++ b/vue/components/ui/templates/home-part/home-part.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, text } from "@storybook/addon-knobs";
 
-storiesOf("Templates", module)
+storiesOf("Components/Templates/Home", module)
     .addDecorator(withKnobs)
     .add("Home", () => ({
         props: {

--- a/vue/components/ui/templates/oauth-part/oauth-part.stories.js
+++ b/vue/components/ui/templates/oauth-part/oauth-part.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, text } from "@storybook/addon-knobs";
 
-storiesOf("Templates", module)
+storiesOf("Components/Templates/OAuth", module)
     .addDecorator(withKnobs)
     .add("OAuth", () => ({
         props: {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-twitch-ui/pull/74#issuecomment-771513137 <br> Fix to to pass the component title path in storiesOf() first argument and the story name in add() first argument. This fixes component search. Reference: https://github.com/storybookjs/storybook/blob/next/lib/core/docs/storiesOf.md#storiesof-api |
| Animated GIF | ![Peek 2021-02-09 12-28](https://user-images.githubusercontent.com/24736423/107363667-5c59d680-6ad2-11eb-913a-57db0b731ea0.gif) |


