### PR TITLE
#39 Add slots to carousel

### DIFF
--- a/vue/components/ui/molecules/carousel/carousel.vue
+++ b/vue/components/ui/molecules/carousel/carousel.vue
@@ -23,6 +23,7 @@
             v-show="arrowsVisibility"
             v-on:click="previous"
         />
+        <slot name="before-slide" />
         <transition-group class="slide-container" tag="div" name="fade">
             <div
                 class="slide"
@@ -41,6 +42,7 @@
                 </div>
             </div>
         </transition-group>
+        <slot name="after-slide" />
         <icon
             class="arrow arrow-next"
             v-bind:color="arrowsColor"


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-twitch/issues/39 |
| Decisions | Add slots to better control the content before and after the carousel's slider. To be used in twitch's `<carousel-model>`. |
