### PR TITLE
#165: Tooltip in listing's search 

### DIFF
--- a/vue/components/ui/molecules/index.js
+++ b/vue/components/ui/molecules/index.js
@@ -35,6 +35,7 @@ import { Steps } from "./steps/steps.vue";
 import { Table } from "./table/table.vue";
 import { TableExpandable } from "./table-expandable/table-expandable.vue";
 import { Tabs } from "./tabs/tabs.vue";
+import { Tooltip } from "./tooltip/tooltip.vue";
 import { TransferList } from "./transfer-list/transfer-list.vue";
 import { UploadArea } from "./upload-area/upload-area.vue";
 
@@ -76,6 +77,7 @@ const install = Vue => {
     Vue.component("table-ripe", Table);
     Vue.component("table-expandable", TableExpandable);
     Vue.component("tabs", Tabs);
+    Vue.component("tooltip", Tooltip);
     Vue.component("transfer-list", TransferList);
     Vue.component("upload-area", UploadArea);
 };
@@ -118,6 +120,7 @@ export {
     Table,
     TableExpandable,
     Tabs,
+    Tooltip,
     TransferList,
     UploadArea
 };

--- a/vue/components/ui/molecules/tooltip/tooltip.stories.js
+++ b/vue/components/ui/molecules/tooltip/tooltip.stories.js
@@ -1,0 +1,102 @@
+import { storiesOf } from "@storybook/vue";
+import { withKnobs, text, select, number, boolean } from "@storybook/addon-knobs";
+
+storiesOf("Components/Molecules/Molecules", module)
+    .addDecorator(withKnobs)
+    .add("Tooltip", () => ({
+        props: {
+            native: {
+                default: boolean("Native", false)
+            },
+            text: {
+                default: text("Text", "I think therefore I am")
+            },
+            visible: {
+                default: boolean("Visible", false)
+            },
+            variant: {
+                default: select(
+                    "Variant",
+                    {
+                        Unset: undefined,
+                        Dark: "dark",
+                        Grey: "grey",
+                        White: "white"
+                    },
+                    undefined
+                )
+            },
+            orientation: {
+                default: select(
+                    "Tooltip Orientation",
+                    {
+                        Unset: undefined,
+                        Top: "top",
+                        Right: "right",
+                        Bottom: "bottom",
+                        Left: "left"
+                    },
+                    undefined
+                )
+            },
+            width: {
+                default: number("Width", null)
+            },
+            borderRadius: {
+                default: text("Border Radius", "4px")
+            },
+            animation: {
+                default: select(
+                    "Animation",
+                    {
+                        Unset: undefined,
+                        None: null,
+                        Fade: "fade"
+                    },
+                    "fade"
+                )
+            },
+            delay: {
+                default: number("Delay", 1000)
+            },
+            duration: {
+                default: number("Duration", 250)
+            }
+        },
+        template: `
+            <div style="margin:200px;">
+                <tooltip
+                    v-bind:text="text"
+                    v-bind:visible="visible"
+                    v-bind:variant="variant"
+                    v-bind:orientation="orientation"
+                    v-bind:width="width"
+                    v-bind:borderRadius="borderRadius"
+                    v-bind:animation="animation"
+                    v-bind:delay="delay"
+                    v-bind:duration="duration"
+                    v-bind:native="native"
+                >
+                    <div style="height:50px;width:50px;background-color:Gold;">Hello, I am a Div.</div>
+                </tooltip>
+                <tooltip
+                    v-bind:visible="visible"
+                    v-bind:variant="variant"
+                    v-bind:orientation="orientation"
+                    v-bind:width="width"
+                    v-bind:border-radius="borderRadius"
+                    v-bind:animation="animation"
+                    v-bind:delay="delay"
+                    v-bind:duration="duration"
+                    v-bind:native="native"
+                    v-if="!native"
+                >
+                    <div style="height:50px;width:50px;background-color:MediumSpringGreen;">Hello, I am also a Div.</div>
+                    <template v-slot:tooltip-content>
+                        The only thing I know is that I know nothing
+                        <image-ripe v-bind:width="200" v-bind:src="'https://cdn.platforme.com/images/platforme.png'" />
+                    </template>
+                </tooltip>
+            </div>
+        `
+    }));

--- a/vue/components/ui/molecules/tooltip/tooltip.stories.js
+++ b/vue/components/ui/molecules/tooltip/tooltip.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, text, select, number, boolean } from "@storybook/addon-knobs";
 
-storiesOf("Components/Molecules/Molecules", module)
+storiesOf("Components/Molecules/Tooltip", module)
     .addDecorator(withKnobs)
     .add("Tooltip", () => ({
         props: {

--- a/vue/components/ui/molecules/tooltip/tooltip.vue
+++ b/vue/components/ui/molecules/tooltip/tooltip.vue
@@ -1,0 +1,275 @@
+<template>
+    <abbr class="tooltip tooltip-native" v-bind:title="text" v-if="native && text">
+        <slot />
+    </abbr>
+    <div class="tooltip tooltip-custom" v-bind:class="classes" v-else>
+        <slot />
+        <transition v-bind:name="animationData">
+            <div class="tooltip-inner" v-bind:style="tooltipInnerStyle" v-show="visibleData">
+                <slot name="tooltip-content">
+                    <div class="tooltip-text" v-bind:style="tooltipTextStyle">
+                        {{ text }}
+                    </div>
+                </slot>
+                <div class="tip" />
+            </div>
+        </transition>
+    </div>
+</template>
+
+<style lang="scss" scoped>
+@import "css/colors.scss";
+
+.tooltip {
+    display: inline-block;
+}
+
+.tooltip-custom {
+    align-items: center;
+    display: inline-flex;
+    justify-content: center;
+    position: relative;
+}
+
+.tooltip-custom > .tooltip-inner {
+    background-color: $dark;
+    box-shadow: 0px 0px 16px rgba(45, 58, 70, 0.25);
+    box-sizing: border-box;
+    color: $white;
+    font-size: 14px;
+    padding: 10px 10px 10px 10px;
+    pointer-events: none;
+    position: absolute;
+    text-align: center;
+    user-select: none;
+    z-index: 1;
+}
+
+body.round .tooltip-custom > .tooltip-inner {
+    border-radius: 4px 4px 4px 4px;
+}
+
+.tooltip-custom.tooltip-variant-dark > .tooltip-inner {
+    background-color: $dark;
+    color: $white;
+}
+
+.tooltip-custom.tooltip-variant-grey > .tooltip-inner {
+    background-color: $grey;
+    color: $white;
+}
+
+.tooltip-custom.tooltip-variant-white > .tooltip-inner {
+    background-color: $white;
+    color: $dark;
+}
+
+.tooltip-custom.tooltip-orientation-top > .tooltip-inner {
+    bottom: calc(100% + 10px);
+}
+
+.tooltip-custom.tooltip-orientation-right > .tooltip-inner {
+    left: calc(100% + 10px);
+}
+
+.tooltip-custom.tooltip-orientation-bottom > .tooltip-inner {
+    top: calc(100% + 10px);
+}
+
+.tooltip.tooltip-orientation-left > .tooltip-inner {
+    right: calc(100% + 10px);
+}
+
+.tooltip-custom > .tooltip-inner > .tip {
+    height: 17px;
+    position: absolute;
+    transform: rotate(-135deg);
+    width: 17px;
+}
+
+.tooltip-custom > .tooltip-inner > .tooltip-text {
+    font-size: 14px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.tooltip-custom.tooltip-variant-dark > .tooltip-inner > .tip {
+    background: linear-gradient(-45deg, $dark 50%, transparent 50%);
+}
+
+.tooltip-custom.tooltip-variant-grey > .tooltip-inner > .tip {
+    background: linear-gradient(-45deg, $grey 50%, transparent 50%);
+}
+
+.tooltip-custom.tooltip-variant-white > .tooltip-inner > .tip {
+    background: linear-gradient(-45deg, $white 50%, transparent 50%);
+}
+
+.tooltip-custom.tooltip-orientation-top > .tooltip-inner > .tip {
+    left: calc(50% - 9px);
+    top: calc(100% - 12px);
+    transform: rotate(45deg);
+}
+
+.tooltip-custom.tooltip-orientation-right > .tooltip-inner > .tip {
+    right: calc(100% - 12px);
+    top: calc(50% - 9px);
+    transform: rotate(135deg);
+}
+
+.tooltip-custom.tooltip-orientation-bottom > .tooltip-inner > .tip {
+    bottom: calc(100% - 12px);
+    left: calc(50% - 9px);
+    transform: rotate(-135deg);
+}
+
+.tooltip-custom.tooltip-orientation-left > .tooltip-inner > .tip {
+    left: calc(100% - 12px);
+    top: calc(50% - 9px);
+    transform: rotate(-45deg);
+}
+</style>
+
+<script>
+export const Tooltip = {
+    name: "tooltip",
+    props: {
+        native: {
+            type: Boolean,
+            default: false
+        },
+        text: {
+            type: String,
+            default: null
+        },
+        visible: {
+            type: Boolean,
+            default: false
+        },
+        disabled: {
+            type: Boolean,
+            default: false
+        },
+        variant: {
+            type: String,
+            default: "dark"
+        },
+        whiteSpace: {
+            type: String,
+            default: null
+        },
+        fontSize: {
+            type: Number,
+            default: null
+        },
+        orientation: {
+            type: String,
+            default: "bottom"
+        },
+        width: {
+            type: Number,
+            default: null
+        },
+        borderRadius: {
+            type: String,
+            default: null
+        },
+        animation: {
+            type: String,
+            default: "fade"
+        },
+        delay: {
+            type: Number,
+            default: 1000
+        },
+        duration: {
+            type: Number,
+            default: 250
+        }
+    },
+    data: function() {
+        return {
+            animationData: null,
+            delayData: null,
+            durationData: null,
+            visibleData: false
+        };
+    },
+    watch: {
+        visible(value) {
+            this.visibleData = value;
+        },
+        visibleData(value) {
+            this.$emit("update:visible", value);
+        },
+        disabled(value) {
+            if (value) this.hide(false);
+        },
+        delay(value) {
+            this.delayData = value;
+        },
+        duration(value) {
+            this.durationData = value;
+        }
+    },
+    computed: {
+        tooltipInnerStyle() {
+            const base = {};
+            if (this.width) base.width = `${this.width}px`;
+            if (this.borderRadius) base.borderRadius = this.borderRadius;
+            if (this.whiteSpace) base["white-space"] = this.whiteSpace;
+            if (this.delayData) base["transition-delay"] = `${this.delayData}ms`;
+            if (this.durationData) base["transition-duration"] = `${this.durationData}ms`;
+            return base;
+        },
+        tooltipTextStyle() {
+            const base = {};
+            if (this.whiteSpace) base["white-space"] = this.whiteSpace;
+            if (this.fontSize) base["font-size"] = `${this.fontSize}px`;
+            return base;
+        },
+        classes() {
+            const base = {};
+            if (this.variant) base["tooltip-variant-" + this.variant] = this.variant;
+            if (this.orientation) {
+                base["tooltip-orientation-" + this.orientation] = this.orientation;
+            }
+            return base;
+        }
+    },
+    methods: {
+        show(animated = true) {
+            if (this.disabled || this.visibleData) return;
+            this._setVisibility(true, animated);
+        },
+        hide(animated = true) {
+            if (!this.visibleData) return;
+            this._setVisibility(false, animated);
+        },
+        scheduleShow() {
+            this.show(true);
+        },
+        _setVisibility(visible, animated) {
+            if (visible && animated) {
+                this.delayData = this.delay;
+            } else {
+                this.delayData = null;
+            }
+
+            if (animated) {
+                this.animationData = this.animation;
+                this.durationData = this.duration;
+                this.visibleData = visible;
+            } else {
+                this.visibleData = visible;
+                this.$nextTick(() => {
+                    this.durationData = null;
+                    this.animationData = "none";
+                });
+            }
+        }
+    }
+};
+
+export default Tooltip;
+</script>

--- a/vue/components/ui/organisms/listing/listing.stories.js
+++ b/vue/components/ui/organisms/listing/listing.stories.js
@@ -65,6 +65,10 @@ storiesOf("Components/Organisms/Listing", module)
             createUrl: {
                 type: String,
                 default: text("Create Url", "https://www.platforme.com")
+            },
+            tooltipSearchText: {
+                type: String,
+                default: text("Search Tooltip text", "")
             }
         },
         data: function() {
@@ -113,6 +117,7 @@ storiesOf("Components/Organisms/Listing", module)
                     v-bind:checkboxes="checkboxes"
                     v-bind:checked-items.sync="checkedItemsData"
                     v-bind:create-url="createUrl"
+                    v-bind:tooltip-search-text="tooltipSearchText"
                 >
                     <template v-slot:icons>
                         <img v-bind:src="img" v-bind:style="imgStyle" />

--- a/vue/components/ui/organisms/listing/listing.vue
+++ b/vue/components/ui/organisms/listing/listing.vue
@@ -17,11 +17,14 @@
             <template v-slot:header-before>
                 <slot v-bind:name="'header-before'">
                     <slot name="header-search">
-                        <div
-                            class="search-container"
+                        <tooltip
+                            class="tooltip-mobile"
+                            v-bind:text="tooltipSearchText"
+                            v-bind:variant="'grey'"
+                            v-bind:border-radius="'5px'"
+                            v-bind:font-size="11"
+                            v-bind:width="210"
                             v-if="isMobileWidth()"
-                            v-on:mouseover="onSearchMouseOver"
-                            v-on:mouseleave="onSearchMouseLeave"
                         >
                             <search
                                 class="search-mobile"
@@ -30,17 +33,7 @@
                                 v-bind:value.sync="filter"
                                 v-bind:loading="loading"
                             />
-                            <tooltip
-                                class="tooltip-mobile"
-                                v-bind:text="tooltipSearchText"
-                                v-bind:visible="visibleTooltip"
-                                v-bind:variant="'grey'"
-                                v-bind:border-radius="'5px'"
-                                v-bind:font-size="11"
-                                v-bind:width="210"
-                                v-if="tooltipSearchText"
-                            />
-                        </div>
+                        </tooltip>
                     </slot>
                 </slot>
             </template>
@@ -75,11 +68,13 @@
                     />
                 </router-link>
                 <slot name="header-search">
-                    <div
-                        class="search-container"
+                    <tooltip
+                        v-bind:text="tooltipSearchText"
+                        v-bind:variant="'grey'"
+                        v-bind:border-radius="'5px'"
+                        v-bind:font-size="11"
+                        v-bind:width="210"
                         v-if="!isMobileWidth()"
-                        v-on:mouseover="onSearchMouseOver"
-                        v-on:mouseleave="onSearchMouseLeave"
                     >
                         <search
                             v-bind:variant="'dark'"
@@ -88,16 +83,7 @@
                             v-bind:value.sync="filter"
                             v-bind:loading="loading"
                         />
-                        <tooltip
-                            v-bind:text="tooltipSearchText"
-                            v-bind:visible="visibleTooltip"
-                            v-bind:variant="'grey'"
-                            v-bind:border-radius="'5px'"
-                            v-bind:font-size="11"
-                            v-bind:width="210"
-                            v-if="tooltipSearchText"
-                        />
-                    </div>
+                    </tooltip>
                 </slot>
             </template>
             <template v-slot:header-buttons-after>
@@ -239,21 +225,16 @@ body.mobile .listing {
     vertical-align: middle;
 }
 
-.listing .container-ripe .search-container {
-    position: relative;
-}
-
 .listing .container-ripe .tooltip {
     text-transform: none;
-    width: 100%;
 }
 
 .listing .container-ripe .tooltip.tooltip-mobile {
-    bottom: 16px;
+    margin-bottom: 16px;
 }
 
 .listing .container-ripe .search.search-mobile {
-    margin: 0px 0px 16px 0px;
+    margin: 0px 0px 0px 0px;
 }
 
 .listing.empty .container-ripe {
@@ -404,8 +385,7 @@ export const Listing = {
             filter: this.context && this.context.filter ? this.context.filter : "",
             filterOptions: null,
             loading: false,
-            visibleLightbox: null,
-            visibleTooltip: false
+            visibleLightbox: null
         };
     },
     watch: {
@@ -445,12 +425,6 @@ export const Listing = {
         },
         onLineupClick(item, index) {
             this.$emit("click:lineup", item, index);
-        },
-        onSearchMouseOver() {
-            this.visibleTooltip = true;
-        },
-        onSearchMouseLeave() {
-            this.visibleTooltip = false;
         }
     },
     computed: {

--- a/vue/components/ui/organisms/listing/listing.vue
+++ b/vue/components/ui/organisms/listing/listing.vue
@@ -19,6 +19,7 @@
                     <slot name="header-search">
                         <div
                             class="search-container"
+                            v-if="isMobileWidth()"
                             v-on:mouseover="onSearchMouseOver"
                             v-on:mouseleave="onSearchMouseLeave"
                         >
@@ -28,7 +29,6 @@
                                 v-bind:placeholder="filterText ? filterText : `Search ${name}`"
                                 v-bind:value.sync="filter"
                                 v-bind:loading="loading"
-                                v-if="isMobileWidth()"
                             />
                             <tooltip
                                 class="tooltip-mobile"
@@ -38,7 +38,7 @@
                                 v-bind:border-radius="'5px'"
                                 v-bind:font-size="11"
                                 v-bind:width="210"
-                                v-if="isMobileWidth() && tooltipSearchText"
+                                v-if="tooltipSearchText"
                             />
                         </div>
                     </slot>
@@ -77,6 +77,7 @@
                 <slot name="header-search">
                     <div
                         class="search-container"
+                        v-if="!isMobileWidth()"
                         v-on:mouseover="onSearchMouseOver"
                         v-on:mouseleave="onSearchMouseLeave"
                     >
@@ -86,7 +87,6 @@
                             v-bind:placeholder="filterText ? filterText : `Search ${name}`"
                             v-bind:value.sync="filter"
                             v-bind:loading="loading"
-                            v-if="!isMobileWidth()"
                         />
                         <tooltip
                             v-bind:text="tooltipSearchText"
@@ -95,7 +95,7 @@
                             v-bind:border-radius="'5px'"
                             v-bind:font-size="11"
                             v-bind:width="210"
-                            v-if="!isMobileWidth() && tooltipSearchText"
+                            v-if="tooltipSearchText"
                         />
                     </div>
                 </slot>
@@ -434,9 +434,6 @@ export const Listing = {
         async refresh() {
             await this.getFilter().refresh();
         },
-        toggleTooltip(value) {
-            this.visibleTooltip = value;
-        },
         getFilter() {
             return this.$refs.filter;
         },
@@ -450,10 +447,10 @@ export const Listing = {
             this.$emit("click:lineup", item, index);
         },
         onSearchMouseOver() {
-            this.toggleTooltip(true);
+            this.visibleTooltip = true;
         },
         onSearchMouseLeave() {
-            this.toggleTooltip(false);
+            this.visibleTooltip = false;
         }
     },
     computed: {

--- a/vue/components/ui/organisms/listing/listing.vue
+++ b/vue/components/ui/organisms/listing/listing.vue
@@ -17,14 +17,30 @@
             <template v-slot:header-before>
                 <slot v-bind:name="'header-before'">
                     <slot name="header-search">
-                        <search
-                            class="search-mobile"
-                            v-bind:variant="'dark'"
-                            v-bind:placeholder="filterText ? filterText : `Search ${name}`"
-                            v-bind:value.sync="filter"
-                            v-bind:loading="loading"
-                            v-if="isMobileWidth()"
-                        />
+                        <div
+                            class="search-container"
+                            v-on:mouseover="onSearchMouseOver"
+                            v-on:mouseleave="onSearchMouseLeave"
+                        >
+                            <search
+                                class="search-mobile"
+                                v-bind:variant="'dark'"
+                                v-bind:placeholder="filterText ? filterText : `Search ${name}`"
+                                v-bind:value.sync="filter"
+                                v-bind:loading="loading"
+                                v-if="isMobileWidth()"
+                            />
+                            <tooltip
+                                class="tooltip-mobile"
+                                v-bind:text="tooltipSearchText"
+                                v-bind:visible="visibleTooltip"
+                                v-bind:variant="'grey'"
+                                v-bind:border-radius="'5px'"
+                                v-bind:font-size="11"
+                                v-bind:width="210"
+                                v-if="isMobileWidth() && tooltipSearchText"
+                            />
+                        </div>
                     </slot>
                 </slot>
             </template>
@@ -59,14 +75,29 @@
                     />
                 </router-link>
                 <slot name="header-search">
-                    <search
-                        v-bind:variant="'dark'"
-                        v-bind:width="searchWidth"
-                        v-bind:placeholder="filterText ? filterText : `Search ${name}`"
-                        v-bind:value.sync="filter"
-                        v-bind:loading="loading"
-                        v-if="!isMobileWidth()"
-                    />
+                    <div
+                        class="search-container"
+                        v-on:mouseover="onSearchMouseOver"
+                        v-on:mouseleave="onSearchMouseLeave"
+                    >
+                        <search
+                            v-bind:variant="'dark'"
+                            v-bind:width="searchWidth"
+                            v-bind:placeholder="filterText ? filterText : `Search ${name}`"
+                            v-bind:value.sync="filter"
+                            v-bind:loading="loading"
+                            v-if="!isMobileWidth()"
+                        />
+                        <tooltip
+                            v-bind:text="tooltipSearchText"
+                            v-bind:visible="visibleTooltip"
+                            v-bind:variant="'grey'"
+                            v-bind:border-radius="'5px'"
+                            v-bind:font-size="11"
+                            v-bind:width="210"
+                            v-if="!isMobileWidth() && tooltipSearchText"
+                        />
+                    </div>
                 </slot>
             </template>
             <template v-slot:header-buttons-after>
@@ -208,6 +239,19 @@ body.mobile .listing {
     vertical-align: middle;
 }
 
+.listing .container-ripe .search-container {
+    position: relative;
+}
+
+.listing .container-ripe .tooltip {
+    text-transform: none;
+    width: 100%;
+}
+
+.listing .container-ripe .tooltip.tooltip-mobile {
+    bottom: 16px;
+}
+
 .listing .container-ripe .search.search-mobile {
     margin: 0px 0px 16px 0px;
 }
@@ -312,6 +356,10 @@ export const Listing = {
             type: String,
             default: null
         },
+        tooltipSearchText: {
+            type: String,
+            default: null
+        },
         defaultReverse: {
             type: Boolean,
             default: false
@@ -356,7 +404,8 @@ export const Listing = {
             filter: this.context && this.context.filter ? this.context.filter : "",
             filterOptions: null,
             loading: false,
-            visibleLightbox: null
+            visibleLightbox: null,
+            visibleTooltip: false
         };
     },
     watch: {
@@ -385,6 +434,9 @@ export const Listing = {
         async refresh() {
             await this.getFilter().refresh();
         },
+        toggleTooltip(value) {
+            this.visibleTooltip = value;
+        },
         getFilter() {
             return this.$refs.filter;
         },
@@ -396,6 +448,12 @@ export const Listing = {
         },
         onLineupClick(item, index) {
             this.$emit("click:lineup", item, index);
+        },
+        onSearchMouseOver() {
+            this.toggleTooltip(true);
+        },
+        onSearchMouseLeave() {
+            this.toggleTooltip(false);
         }
     },
     computed: {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Related to https://github.com/ripe-tech/ripe-pulse/issues/165|
| Dependencies | -- |
| Storybook | Tooltip storybook: https://ripe-components-vue-git-ms-165-tooltip-platforme.vercel.app/?path=/story/components-molecules-tooltip--tooltip <br> Listing storybook with tooltip option: https://ripe-components-vue-git-ms-165-tooltip-platforme.vercel.app/?path=/story/components-organisms-listing--listing | 
| Decisions | Tooltip component ported from `white`. Added tooltip to `listing` search (not added in `search` component because it would be very difficult to show the tooltip without being cut out - uses the parent dimensions as reference for positioning). |
| Animated GIF | `Pulse` examples with `listing`: <br>![Screenshot from 2021-03-01 12-17-36](https://user-images.githubusercontent.com/25725586/109497342-d2c27680-7a89-11eb-850f-f22bae44f589.png)<br>![Screenshot from 2021-03-01 12-19-18](https://user-images.githubusercontent.com/25725586/109497347-d3f3a380-7a89-11eb-957c-b458c379e746.png)|
