### PR TITLE
Select: Mobile native toggle

### DIFF
--- a/vue/components/ui/molecules/select/select.vue
+++ b/vue/components/ui/molecules/select/select.vue
@@ -213,7 +213,7 @@ export const Select = {
         },
         mobileNative: {
             type: Boolean,
-            default: true
+            default: false
         }
     },
     data: function() {

--- a/vue/components/ui/molecules/select/select.vue
+++ b/vue/components/ui/molecules/select/select.vue
@@ -103,7 +103,7 @@
 }
 
 .select .dropdown-select {
-    background-image: none;
+    background-image: unset;
 }
 
 .select.direction-top .select-container .select-button {

--- a/vue/components/ui/molecules/select/select.vue
+++ b/vue/components/ui/molecules/select/select.vue
@@ -210,7 +210,7 @@ export const Select = {
         },
         mobileNative: {
             type: Boolean,
-            default: false
+            default: true
         }
     },
     data: function() {

--- a/vue/components/ui/molecules/select/select.vue
+++ b/vue/components/ui/molecules/select/select.vue
@@ -4,7 +4,7 @@
         <select
             class="dropdown-select"
             v-bind:value="value"
-            v-if="mobileNative && isDevice()"
+            v-if="isDevice()"
             v-on:change="event => onSelectChange(event.target.value)"
         >
             <option
@@ -210,10 +210,6 @@ export const Select = {
         owners: {
             type: Node | Array,
             default: () => []
-        },
-        mobileNative: {
-            type: Boolean,
-            default: false
         }
     },
     data: function() {

--- a/vue/components/ui/molecules/select/select.vue
+++ b/vue/components/ui/molecules/select/select.vue
@@ -102,7 +102,10 @@
     white-space: nowrap;
 }
 
-.select.direction-top .dropdown-select,
+.select .dropdown-select {
+    background-image: none;
+}
+
 .select.direction-top .select-container .select-button {
     background-image: url("~./assets/chevron-up.svg");
 }

--- a/vue/components/ui/molecules/select/select.vue
+++ b/vue/components/ui/molecules/select/select.vue
@@ -4,7 +4,7 @@
         <select
             class="dropdown-select"
             v-bind:value="value"
-            v-if="isDevice()"
+            v-if="mobileNative && isDevice()"
             v-on:change="event => onSelectChange(event.target.value)"
         >
             <option
@@ -207,6 +207,10 @@ export const Select = {
         owners: {
             type: Node | Array,
             default: () => []
+        },
+        mobileNative: {
+            type: Boolean,
+            default: false
         }
     },
     data: function() {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | There is a double arrow problem in `<select-twitch>` which happens when we have a mobile user agent. |
| Decisions | Hide `background-image` when using native select . |
| Animated GIF | The double arrow bug. <br> ![image](https://user-images.githubusercontent.com/24736423/110008246-68bd0200-7d13-11eb-9d20-19353a9f0df5.png) |
