### PR TITLE
Select: fix text vertical alignment

### DIFF
--- a/vue/components/ui/molecules/select/select.vue
+++ b/vue/components/ui/molecules/select/select.vue
@@ -91,7 +91,7 @@
     font-size: 13px;
     height: 34px;
     letter-spacing: 0.25px;
-    line-height: 34px;
+    line-height: 30px;
     outline: none;
     overflow: hidden;
     padding-left: 12px;


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Select has slight vertical misalignment <br> ![image](https://user-images.githubusercontent.com/24736423/110146980-1511ed80-7dd3-11eb-8cfb-f6b9bc7e4f16.png) |
| Decisions | In order to vertical align using `line-height`, it should have the same amount of height as the container it is in. The container has 34px but 4px of those are for the border so in reality it has 30px. |
| Animated GIF | ![image](https://user-images.githubusercontent.com/24736423/110147022-1f33ec00-7dd3-11eb-9cd4-91c48cb5be98.png) |
