### PR TITLE
feat: switcher text and color props

### DIFF
--- a/vue/components/ui/atoms/switcher/switcher.stories.js
+++ b/vue/components/ui/atoms/switcher/switcher.stories.js
@@ -1,5 +1,5 @@
 import { storiesOf } from "@storybook/vue";
-import { withKnobs, boolean } from "@storybook/addon-knobs";
+import { withKnobs, boolean, text } from "@storybook/addon-knobs";
 
 storiesOf("Components/Atoms/Switcher", module)
     .addDecorator(withKnobs)
@@ -10,6 +10,15 @@ storiesOf("Components/Atoms/Switcher", module)
             },
             disabled: {
                 default: boolean("Disabled", false)
+            },
+            checkedColor: {
+                default: text("Checked Color", null)
+            },
+            checkedText: {
+                default: text("Checked Text", null)
+            },
+            uncheckedText: {
+                default: text("Unchecked Text", null)
             }
         },
         data: function() {
@@ -26,7 +35,11 @@ storiesOf("Components/Atoms/Switcher", module)
             <div>
                 <switcher
                     v-bind:checked.sync="checkedData"
-                    v-bind:disabled="disabled" />
+                    v-bind:disabled="disabled"
+                    v-bind:checked-color="checkedColor"
+                    v-bind:checked-text="checkedText"
+                    v-bind:unchecked-text="uncheckedText"
+                />
                 <p>The switcher's value is: {{ checkedData }}</p>
             </div>
         `

--- a/vue/components/ui/atoms/switcher/switcher.stories.js
+++ b/vue/components/ui/atoms/switcher/switcher.stories.js
@@ -1,5 +1,5 @@
 import { storiesOf } from "@storybook/vue";
-import { withKnobs, boolean, text } from "@storybook/addon-knobs";
+import { withKnobs, boolean, select, text } from "@storybook/addon-knobs";
 
 storiesOf("Components/Atoms/Switcher", module)
     .addDecorator(withKnobs)
@@ -11,11 +11,16 @@ storiesOf("Components/Atoms/Switcher", module)
             disabled: {
                 default: boolean("Disabled", false)
             },
-            checkedColor: {
-                default: text("Checked Color", "#1d1d1d")
-            },
-            uncheckedColor: {
-                default: text("Unchecked Color", "#cccccc")
+            variant: {
+                default: select(
+                    "Variant",
+                    {
+                        Unset: null,
+                        Colored: "colored",
+                        Grey: "grey"
+                    },
+                    null
+                )
             },
             checkedText: {
                 default: text("Checked Text", null)
@@ -39,7 +44,7 @@ storiesOf("Components/Atoms/Switcher", module)
                 <switcher
                     v-bind:checked.sync="checkedData"
                     v-bind:disabled="disabled"
-                    v-bind:checked-color="checkedColor"
+                    v-bind:variant="variant || undefined"
                     v-bind:checked-text="checkedText"
                     v-bind:unchecked-text="uncheckedText"
                 />

--- a/vue/components/ui/atoms/switcher/switcher.stories.js
+++ b/vue/components/ui/atoms/switcher/switcher.stories.js
@@ -12,7 +12,10 @@ storiesOf("Components/Atoms/Switcher", module)
                 default: boolean("Disabled", false)
             },
             checkedColor: {
-                default: text("Checked Color", null)
+                default: text("Checked Color", "#1d1d1d")
+            },
+            uncheckedColor: {
+                default: text("Unchecked Color", "#cccccc")
             },
             checkedText: {
                 default: text("Checked Text", null)

--- a/vue/components/ui/atoms/switcher/switcher.vue
+++ b/vue/components/ui/atoms/switcher/switcher.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="switcher" v-bind:class="classes">
-        <div class="switcher-button-container" v-bind:style="styleContainer" v-on:click="onClick">
+        <div class="switcher-button-container" v-on:click="onClick">
             <div class="switcher-button" v-bind:style="toggleAnimation" />
         </div>
         <div class="switcher-text" v-if="text">
@@ -27,10 +27,29 @@
     border-radius: 500px 500px 500px 500px;
     cursor: pointer;
     height: 20px;
-    position: relative;
     transition-duration: 0.4s;
     transition-property: border-color, background-color;
     width: 40px;
+}
+
+.switcher.switcher-colored > .switcher-button-container {
+    border-color: $upper-grey;
+    background-color: $upper-grey;
+}
+
+.switcher.switcher-colored.checked > .switcher-button-container {
+    border-color: $green;
+    background-color: $green;
+}
+
+.switcher.switcher-grey > .switcher-button-container {
+    border-color: $upper-grey;
+    background-color: $upper-grey;
+}
+
+.switcher.switcher-grey.checked > .switcher-button-container {
+    border-color: $black;
+    background-color: $black;
 }
 
 .switcher > .switcher-button-container > .switcher-button {
@@ -60,13 +79,9 @@ export const Switcher = {
             type: Boolean,
             default: false
         },
-        checkedColor: {
+        variant: {
             type: String,
-            default: "#1d1d1d"
-        },
-        uncheckedColor: {
-            type: String,
-            default: "#cccccc"
+            default: "colored"
         },
         checkedText: {
             type: String,
@@ -95,6 +110,7 @@ export const Switcher = {
                 checked: this.checkedData,
                 disabled: this.disabled
             };
+            base[`switcher-${this.variant}`] = true;
             return base;
         },
         styleContainer() {

--- a/vue/components/ui/atoms/switcher/switcher.vue
+++ b/vue/components/ui/atoms/switcher/switcher.vue
@@ -113,13 +113,6 @@ export const Switcher = {
             base[`switcher-${this.variant}`] = true;
             return base;
         },
-        styleContainer() {
-            const base = {
-                borderColor: this.checkedData ? this.checkedColor : this.uncheckedColor,
-                backgroundColor: this.checkedData ? this.checkedColor : this.uncheckedColor
-            };
-            return base;
-        },
         text() {
             return this.checkedData ? this.checkedText : this.uncheckedText;
         }

--- a/vue/components/ui/atoms/switcher/switcher.vue
+++ b/vue/components/ui/atoms/switcher/switcher.vue
@@ -33,23 +33,23 @@
 }
 
 .switcher.switcher-colored > .switcher-button-container {
-    border-color: $upper-grey;
     background-color: $upper-grey;
+    border-color: $upper-grey;
 }
 
 .switcher.switcher-colored.checked > .switcher-button-container {
-    border-color: $green;
     background-color: $green;
+    border-color: $green;
 }
 
 .switcher.switcher-grey > .switcher-button-container {
-    border-color: $upper-grey;
     background-color: $upper-grey;
+    border-color: $upper-grey;
 }
 
 .switcher.switcher-grey.checked > .switcher-button-container {
-    border-color: $black;
     background-color: $black;
+    border-color: $black;
 }
 
 .switcher > .switcher-button-container > .switcher-button {

--- a/vue/components/ui/atoms/switcher/switcher.vue
+++ b/vue/components/ui/atoms/switcher/switcher.vue
@@ -1,11 +1,6 @@
 <template>
-    <div class="switcher">
-        <div
-            class="switcher-container"
-            v-bind:style="style"
-            v-bind:class="classes"
-            v-on:click="onClick"
-        >
+    <div class="switcher" v-bind:class="classes">
+        <div class="switcher-button-container" v-bind:style="styleContainer" v-on:click="onClick">
             <div class="switcher-button" v-bind:style="toggleAnimation" />
         </div>
         <div class="switcher-text" v-if="text">
@@ -22,7 +17,12 @@
     display: inline-flex;
 }
 
-.switcher-container {
+.switcher.disabled {
+    cursor: default;
+    opacity: 0.3;
+}
+
+.switcher > .switcher-button-container {
     border: 2px solid;
     border-radius: 500px 500px 500px 500px;
     cursor: pointer;
@@ -33,12 +33,7 @@
     width: 40px;
 }
 
-.switcher.disabled {
-    cursor: default;
-    opacity: 0.3;
-}
-
-.switcher-container > .switcher-button {
+.switcher > .switcher-button-container > .switcher-button {
     background-color: $white;
     border-radius: 10px 10px 10px 10px;
     height: 20px;
@@ -95,17 +90,17 @@ export const Switcher = {
             }
             return base;
         },
-        style() {
-            const base = {
-                borderColor: this.checkedData ? this.checkedColor : this.uncheckedColor,
-                backgroundColor: this.checkedData ? this.checkedColor : this.uncheckedColor
-            };
-            return base;
-        },
         classes() {
             const base = {
                 checked: this.checkedData,
                 disabled: this.disabled
+            };
+            return base;
+        },
+        styleContainer() {
+            const base = {
+                borderColor: this.checkedData ? this.checkedColor : this.uncheckedColor,
+                backgroundColor: this.checkedData ? this.checkedColor : this.uncheckedColor
             };
             return base;
         },

--- a/vue/components/ui/atoms/switcher/switcher.vue
+++ b/vue/components/ui/atoms/switcher/switcher.vue
@@ -1,6 +1,13 @@
 <template>
-    <div class="switcher" v-bind:style="style" v-bind:class="classes" v-on:click="onClick">
-        <div class="switcher-button" v-bind:style="toggleAnimation" />
+    <div class="switcher">
+        <div
+            class="switcher-container"
+            v-bind:style="style"
+            v-bind:class="classes"
+            v-on:click="onClick"
+        >
+            <div class="switcher-button" v-bind:style="toggleAnimation" />
+        </div>
         <div class="switcher-text" v-if="text">
             {{ text }}
         </div>
@@ -11,8 +18,12 @@
 @import "css/variables.scss";
 
 .switcher {
-    background-color: $upper-grey;
-    border: 2px solid $upper-grey;
+    align-items: center;
+    display: inline-flex;
+}
+
+.switcher-container {
+    border: 2px solid;
     border-radius: 500px 500px 500px 500px;
     cursor: pointer;
     height: 20px;
@@ -27,7 +38,7 @@
     opacity: 0.3;
 }
 
-.switcher > .switcher-button {
+.switcher-container > .switcher-button {
     background-color: $white;
     border-radius: 10px 10px 10px 10px;
     height: 20px;
@@ -38,10 +49,7 @@
 
 .switcher > .switcher-text {
     font-size: 12px;
-    left: 50px;
-    line-height: 12px;
-    position: absolute;
-    top: 4px;
+    margin-left: 5px;
 }
 </style>
 
@@ -59,7 +67,11 @@ export const Switcher = {
         },
         checkedColor: {
             type: String,
-            default: null
+            default: "#1d1d1d"
+        },
+        uncheckedColor: {
+            type: String,
+            default: "#cccccc"
         },
         checkedText: {
             type: String,
@@ -84,11 +96,10 @@ export const Switcher = {
             return base;
         },
         style() {
-            const base = {};
-            if (this.checkedData) {
-                base.borderColor = this.checkedColor || "#1d1d1d";
-                base.backgroundColor = this.checkedColor || "#1d1d1d";
-            }
+            const base = {
+                borderColor: this.checkedData ? this.checkedColor : this.uncheckedColor,
+                backgroundColor: this.checkedData ? this.checkedColor : this.uncheckedColor
+            };
             return base;
         },
         classes() {

--- a/vue/components/ui/atoms/switcher/switcher.vue
+++ b/vue/components/ui/atoms/switcher/switcher.vue
@@ -1,6 +1,9 @@
 <template>
     <div class="switcher" v-bind:style="style" v-bind:class="classes" v-on:click="onClick">
         <div class="switcher-button" v-bind:style="toggleAnimation" />
+        <div class="switcher-text" v-if="text">
+            {{ text }}
+        </div>
     </div>
 </template>
 
@@ -13,6 +16,7 @@
     border-radius: 500px 500px 500px 500px;
     cursor: pointer;
     height: 20px;
+    position: relative;
     transition-duration: 0.4s;
     transition-property: border-color, background-color;
     width: 40px;
@@ -31,6 +35,14 @@
     transition-property: margin;
     width: 20px;
 }
+
+.switcher > .switcher-text {
+    font-size: 12px;
+    left: 50px;
+    line-height: 12px;
+    position: absolute;
+    top: 4px;
+}
 </style>
 
 <script>
@@ -44,6 +56,18 @@ export const Switcher = {
         disabled: {
             type: Boolean,
             default: false
+        },
+        checkedColor: {
+            type: String,
+            default: null
+        },
+        checkedText: {
+            type: String,
+            default: null
+        },
+        uncheckedText: {
+            type: String,
+            default: null
         }
     },
     data: function() {
@@ -62,8 +86,8 @@ export const Switcher = {
         style() {
             const base = {};
             if (this.checkedData) {
-                base.borderColor = "#1d1d1d";
-                base.backgroundColor = "#1d1d1d";
+                base.borderColor = this.checkedColor || "#1d1d1d";
+                base.backgroundColor = this.checkedColor || "#1d1d1d";
             }
             return base;
         },
@@ -73,6 +97,9 @@ export const Switcher = {
                 disabled: this.disabled
             };
             return base;
+        },
+        text() {
+            return this.checkedData ? this.checkedText : this.uncheckedText;
         }
     },
     watch: {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Related to https://github.com/ripe-tech/ripe-twitch/issues/42 |
| Dependencies | -- |
| Decisions | Switcher support for text on checked and unchecked status, and checked color. <br><br> Necessary due to the design in `twitch-admin-ui`, such as the `edit` and `creation`pages: <br>![image](https://user-images.githubusercontent.com/25725586/110812999-04a0bd80-8280-11eb-9f67-968911ec9179.png) <br> ![image](https://user-images.githubusercontent.com/25725586/110813068-12564300-8280-11eb-8e70-9232ec20d4c1.png)|
| Animated GIF |![switcher-text](https://user-images.githubusercontent.com/25725586/110661931-f2118000-81bc-11eb-802e-9a2f9697168c.gif)![switcher-use-case](https://user-images.githubusercontent.com/25725586/110661938-f342ad00-81bc-11eb-84d7-44f2c121f320.gif)|
