### PR TITLE
feat: allow form components override

### DIFF
--- a/vue/components/ui/organisms/container-form/container-form.vue
+++ b/vue/components/ui/organisms/container-form/container-form.vue
@@ -6,7 +6,16 @@
         v-on:header-button:click="onHeaderButtonClick"
         v-on:header-button:click:delete="onDeleteClick"
     >
-        <form-ripe v-bind="formProps" v-bind:fields="fields" v-bind:values.sync="valuesData" />
+        <form-ripe v-bind="formProps" v-bind:fields="fields" v-bind:values.sync="valuesData">
+            <slot v-bind:name="slot" v-for="slot in Object.keys($slots)" v-bind:slot="slot" />
+            <template
+                v-for="slot in Object.keys($scopedSlots)"
+                v-bind:slot="slot"
+                slot-scope="scope"
+            >
+                <slot v-bind:name="slot" v-bind="scope" />
+            </template>
+        </form-ripe>
     </container-ripe>
 </template>
 

--- a/vue/components/ui/organisms/form/form.vue
+++ b/vue/components/ui/organisms/form/form.vue
@@ -29,7 +29,8 @@
                                 <slot
                                     v-bind:name="field.value"
                                     v-bind:field="field"
-                                    v-bind:values="values"
+                                    v-bind:props="field.props"
+                                    v-bind:value="values[field.value]"
                                     v-bind:on-value="onValue"
                                 >
                                     <template

--- a/vue/components/ui/organisms/form/form.vue
+++ b/vue/components/ui/organisms/form/form.vue
@@ -26,72 +26,81 @@
                                 v-bind="field.formInputProps"
                                 v-bind:key="field.value"
                             >
-                                <template
-                                    v-if="field.type === 'text' && field.meta === 'image-url'"
+                                <slot
+                                    v-bind:name="field.value"
+                                    v-bind:field="field"
+                                    v-bind:values="values"
+                                    v-bind:on-value="onValue"
                                 >
+                                    <template
+                                        v-if="field.type === 'text' && field.meta === 'image-url'"
+                                    >
+                                        <input-ripe
+                                            v-bind:type="inputType(field)"
+                                            v-bind="field.props"
+                                            v-bind:value="values[field.value]"
+                                            v-on:update:value="value => onValue(field.value, value)"
+                                        />
+                                        <image-ripe
+                                            class="text-image"
+                                            v-bind:src="values[field.value] || field.imageSrc"
+                                            v-if="values[field.value] || field.imageSrc"
+                                        />
+                                    </template>
+                                    <textarea-ripe
+                                        v-bind="field.props"
+                                        v-bind:value="values[field.value]"
+                                        v-else-if="
+                                            field.type === 'text' && field.meta === 'longtext'
+                                        "
+                                        v-on:update:value="value => onValue(field.value, value)"
+                                    />
                                     <input-ripe
                                         v-bind:type="inputType(field)"
                                         v-bind="field.props"
                                         v-bind:value="values[field.value]"
+                                        v-else-if="field.type === 'text'"
                                         v-on:update:value="value => onValue(field.value, value)"
                                     />
-                                    <image-ripe
-                                        class="text-image"
-                                        v-bind:src="values[field.value] || field.imageSrc"
-                                        v-if="values[field.value] || field.imageSrc"
-                                    />
-                                </template>
-                                <textarea-ripe
-                                    v-bind="field.props"
-                                    v-bind:value="values[field.value]"
-                                    v-else-if="field.type === 'text' && field.meta === 'longtext'"
-                                    v-on:update:value="value => onValue(field.value, value)"
-                                />
-                                <input-ripe
-                                    v-bind:type="inputType(field)"
-                                    v-bind="field.props"
-                                    v-bind:value="values[field.value]"
-                                    v-else-if="field.type === 'text'"
-                                    v-on:update:value="value => onValue(field.value, value)"
-                                />
-                                <select-ripe
-                                    v-bind="field.props"
-                                    v-bind:value="values[field.value]"
-                                    v-else-if="field.type === 'enum'"
-                                    v-on:update:value="value => onValue(field.value, value)"
-                                >
-                                    <template v-slot:selected="{ item }">
-                                        <slot
-                                            v-bind:name="`${field.value}-select-selected`"
-                                            v-bind:item="item"
-                                        >
+                                    <select-ripe
+                                        v-bind="field.props"
+                                        v-bind:value="values[field.value]"
+                                        v-else-if="field.type === 'enum'"
+                                        v-on:update:value="value => onValue(field.value, value)"
+                                    >
+                                        <template v-slot:selected="{ item }">
                                             <slot
-                                                v-bind:name="'select-selected'"
+                                                v-bind:name="`${field.value}-select-selected`"
                                                 v-bind:item="item"
-                                            />
-                                        </slot>
-                                    </template>
-                                    <template v-slot="{ item }">
-                                        <slot
-                                            v-bind:name="`${field.value}-select`"
-                                            v-bind:item="item"
-                                        >
-                                            <slot v-bind:name="'select'" v-bind:item="item" />
-                                        </slot>
-                                    </template>
-                                </select-ripe>
-                                <switcher
-                                    v-bind="field.props"
-                                    v-bind:checked="values[field.value]"
-                                    v-else-if="field.type === 'boolean'"
-                                    v-on:update:checked="value => onValue(field.value, value)"
-                                />
-                                <files-uploader
-                                    v-bind="field.props"
-                                    v-bind:files="values[field.value]"
-                                    v-else-if="field.type === 'file'"
-                                    v-on:update:files="value => onValue(field.value, value)"
-                                />
+                                            >
+                                                <slot
+                                                    v-bind:name="'select-selected'"
+                                                    v-bind:item="item"
+                                                />
+                                            </slot>
+                                        </template>
+                                        <template v-slot="{ item }">
+                                            <slot
+                                                v-bind:name="`${field.value}-select`"
+                                                v-bind:item="item"
+                                            >
+                                                <slot v-bind:name="'select'" v-bind:item="item" />
+                                            </slot>
+                                        </template>
+                                    </select-ripe>
+                                    <switcher
+                                        v-bind="field.props"
+                                        v-bind:checked="values[field.value]"
+                                        v-else-if="field.type === 'boolean'"
+                                        v-on:update:checked="value => onValue(field.value, value)"
+                                    />
+                                    <files-uploader
+                                        v-bind="field.props"
+                                        v-bind:files="values[field.value]"
+                                        v-else-if="field.type === 'file'"
+                                        v-on:update:files="value => onValue(field.value, value)"
+                                    />
+                                </slot>
                             </form-input>
                         </template>
                     </div>


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Related to https://github.com/ripe-tech/ripe-twitch/issues/84 |
| Dependencies | -- |
| Decisions | Code necessary to allow override form components with custom ones. <br><br> Its necessary to override the components of a form if a new more specific is needed (for example in the twitch-admin, instead of a switcher, its necessary to use a switcher with a specific behaviour). For that to be possible, a `slot` was added to the `form-input` value and the code necessary to override that slot was added to the container-form, so that its possible to use that slot when using the `entity-create` component. |
| Animated GIF | To allow something like <br> ![image](https://user-images.githubusercontent.com/25725586/110773361-9266b380-8254-11eb-91aa-155cf0e2351e.png)|
