### PR TITLE
fix: remove onSave call from button click

### DIFF
--- a/vue/components/ui/organisms/form/form.vue
+++ b/vue/components/ui/organisms/form/form.vue
@@ -134,7 +134,6 @@
                     ...acceptButtonProps
                 }"
                 v-if="onSave"
-                v-on:click="onSubmit"
             />
         </div>
     </form>


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Originated from https://github.com/ripe-tech/ripe-twitch/issues/84 |
| Dependencies | -- |
| Decisions | The submit action of the form was calling the save callback twice. This was due to the fact that the `onSave` function was being called both on the form submit and on the button click action. https://github.com/ripe-tech/ripe-components-vue/blob/39a41539197931730be306830f94bcc6d88b36d1/vue/components/ui/organisms/form/form.vue#L2 Removed the button action and the call is made correctly only once. |
| Animated GIF |**Problem**: <br> ![form-problem](https://user-images.githubusercontent.com/25725586/110806247-c6a09b00-8279-11eb-8fa8-72ec7804898e.gif) <br> **After fix**:<br>![form-problem-fix](https://user-images.githubusercontent.com/25725586/110806279-d02a0300-8279-11eb-8828-213ffd804087.gif)|
