### PR TITLE
feat: entity-create discard callback

### DIFF
--- a/vue/components/ui/organisms/entity-create/entity-create.vue
+++ b/vue/components/ui/organisms/entity-create/entity-create.vue
@@ -83,6 +83,13 @@ export const EntityCreate = {
             default: null
         },
         /**
+         * Method to be called on discard.
+         */
+        onDiscardCallback: {
+            type: Function,
+            default: null
+        },
+        /**
          * Props that can be used to customize the form.
          */
         formProps: {
@@ -125,6 +132,8 @@ export const EntityCreate = {
         },
         async onDiscard() {
             this.clearForm();
+            if (!this.onDiscardCallback) return;
+            await this.onDiscardCallback();
         },
         async onSave(values) {
             await this.createEntity(values);


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Originated from https://github.com/ripe-tech/ripe-twitch/issues/84 |
| Dependencies | -- |
| Decisions | In some cases (twitch-admin for example), the discard button can have other functionality (and be called `Cancel` or other things instead of `Discard`). In twitch-admin, the button is called `Cancel` and when clicked, it should redirect to the listing page. Currently, the button only cleans the values of the form and there is no way of doing additional logic.<br> A prop was added called `onDiscardCallback` that when defined is called when the discard button is clicked. |
| Animated GIF | -- |
