### PR TITLE
feat: added slot to listing's header button

### DIFF
--- a/vue/components/ui/organisms/listing/listing.vue
+++ b/vue/components/ui/organisms/listing/listing.vue
@@ -51,22 +51,24 @@
             </template>
             <template v-slot:header-buttons-inside-after>
                 <slot v-bind:name="'header-buttons-inside-after'" />
-                <router-link
-                    class="button-create"
-                    v-bind:to="createUrl"
-                    v-if="createUrl"
-                    v-slot="{ href, navigate }"
-                >
-                    <button-color
-                        v-bind:text="`Create ${name}`"
-                        v-bind:size="'small'"
-                        v-bind:alignment="'left'"
-                        v-bind:icon="'add'"
-                        v-bind:min-width="0"
-                        v-bind:href="href"
-                        v-on:click="navigate"
-                    />
-                </router-link>
+                <slot v-bind:name="'header-button-create'">
+                    <router-link
+                        class="button-create"
+                        v-bind:to="createUrl"
+                        v-if="createUrl"
+                        v-slot="{ href, navigate }"
+                    >
+                        <button-color
+                            v-bind:text="`Create ${name}`"
+                            v-bind:size="'small'"
+                            v-bind:alignment="'left'"
+                            v-bind:icon="'add'"
+                            v-bind:min-width="0"
+                            v-bind:href="href"
+                            v-on:click="navigate"
+                        />
+                    </router-link>
+                </slot>
                 <slot name="header-search">
                     <tooltip
                         v-bind:text="tooltipSearchText"


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Related to https://github.com/ripe-tech/ripe-twitch/issues/83|
| Dependencies | -- |
| Decisions | This slot is necessary for overriding the create entity button in the listing's header. For example, in this screen below, the button needs to have a different text and icon. In addition to this, the button opens a modal instead of redirecting to another page. ![image](https://user-images.githubusercontent.com/25725586/111659922-80ad7f00-8805-11eb-80d9-b839e6c7a1df.png) <br> To allow that kind of behaviour, the easier solution was to create a slot, which changes nothing in the overall behaviour of the component. |
| Animated GIF | -- |
