### PR TITLE
#39 Carousel - infinite slide and double slide fix

### DIFF
--- a/vue/components/ui/molecules/carousel/carousel.vue
+++ b/vue/components/ui/molecules/carousel/carousel.vue
@@ -373,7 +373,7 @@ export const Carousel = {
                 return;
             }
             this.action = "previous";
-            this.valueData = (this.valueData + 1) % this.items.length;
+            this.valueData = this.valueData - 1 < 0 ? this.items.length - 1 : this.valueData - 1;
         },
         getCursorPosition(event) {
             const deviceEvent = event.type.startsWith("touch") ? event.touches[0] : event;

--- a/vue/components/ui/molecules/carousel/carousel.vue
+++ b/vue/components/ui/molecules/carousel/carousel.vue
@@ -347,7 +347,7 @@ export const Carousel = {
     watch: {
         valueData(value, previousValue) {
             this.action = this.action || (value > previousValue ? "next" : "previous");
-            this.$emit("update:value", value);
+            this.$emit("update:value", value, previousValue);
         },
         value(value) {
             this.valueData = value;

--- a/vue/components/ui/molecules/carousel/carousel.vue
+++ b/vue/components/ui/molecules/carousel/carousel.vue
@@ -282,6 +282,13 @@ export const Carousel = {
             default: "fade"
         },
         /**
+         * Weather or not accepts sliding actions only after animation ends.
+         */
+        waitAnimation: {
+            type: Boolean,
+            default: false
+        },
+        /**
          * Weather or not sliding against an end should wrap to the other end.
          */
         wrap: {
@@ -351,7 +358,7 @@ export const Carousel = {
     },
     methods: {
         next() {
-            if (this.animating) return;
+            if (this.waitAnimation && this.animating) return;
             if (!this.wrap && this.valueData === this.items.length - 1) {
                 this.animationData = "slide-right-fake";
                 return;
@@ -360,7 +367,7 @@ export const Carousel = {
             this.valueData = (this.valueData + 1) % this.items.length;
         },
         previous() {
-            if (this.animating) return;
+            if (this.waitAnimation && this.animating) return;
             if (!this.wrap && this.valueData === 0) {
                 this.animationData = "slide-left-fake";
                 return;


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-twitch/issues/39 |
| Decisions | - Add infinite slide to the same side of the swipe instead of opposite side when moving from the edges. <br> - Fixes when there are only 2 elements and user clicks several times in the arrow by disabling sliding actions when animating. |
| Animated GIF | ![Peek 2021-03-19 14-59](https://user-images.githubusercontent.com/24736423/111800282-b4e77500-88c3-11eb-93d4-202a9bbbc186.gif) |




