### PR TITLE
fix: override icon size and margin-top to fix blurry icon

### DIFF
--- a/vue/components/ui/organisms/listing/listing.vue
+++ b/vue/components/ui/organisms/listing/listing.vue
@@ -63,7 +63,6 @@
                             v-bind:size="'small'"
                             v-bind:alignment="'left'"
                             v-bind:icon="'add'"
-                            v-bind:icon-size="17"
                             v-bind:min-width="0"
                             v-bind:href="href"
                             v-on:click="navigate"

--- a/vue/components/ui/organisms/listing/listing.vue
+++ b/vue/components/ui/organisms/listing/listing.vue
@@ -63,6 +63,7 @@
                             v-bind:size="'small'"
                             v-bind:alignment="'left'"
                             v-bind:icon="'add'"
+                            v-bind:icon-size="17"
                             v-bind:min-width="0"
                             v-bind:href="href"
                             v-on:click="navigate"
@@ -220,6 +221,12 @@ body.mobile .listing {
 .listing .container-ripe .button-create {
     display: inline-block;
     vertical-align: middle;
+}
+
+.listing .container-ripe .button-create ::v-deep .icon {
+    height: 17px;
+    margin-top: 7px;
+    width: 17px;
 }
 
 .listing .container-ripe .search {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-twitch/issues/84#issuecomment-806551523 |
| Dependencies | |
| Decisions | Although the fix talked about was changing the width/height of the icon by prop, it would not change, since `button-color` is setting the size of the icon using css (18px). Using a prop in `button-color` to control the width and height of the icon and then using a computed style, it would still be necessary to also add another prop to control the icon margin top (its dependent on the size). <br> This would be a big change only for this specific fix. The solution here presented simply overrides the style in listing, where the icon is already pre-defined. |
| Animated GIF | **Before**:<br>![image](https://user-images.githubusercontent.com/25725586/112475592-e602f200-8d68-11eb-8d43-e89b4b196119.png) <br>**Now**: ![image](https://user-images.githubusercontent.com/25725586/112475546-d5eb1280-8d68-11eb-8a1f-5380f31e6458.png) |
