### PR TITLE
fix: highlight color and highlight timing

### DIFF
--- a/vue/components/ui/atoms/image-item/image-item.stories.js
+++ b/vue/components/ui/atoms/image-item/image-item.stories.js
@@ -26,6 +26,9 @@ storiesOf("Components/Atoms/Image Item", module)
             highlight: {
                 default: boolean("Highlight", false)
             },
+            highlightColor: {
+                default: text("Highlight Color", "#aeffe2")
+            },
             animationDuration: {
                 default: number("Animation Duration", 2000)
             },
@@ -60,6 +63,7 @@ storiesOf("Components/Atoms/Image Item", module)
                 v-bind:width="width"
                 v-bind:text-align="textAlign"
                 v-bind:highlight="highlight"
+                v-bind:highlight-color="highlightColor"
                 v-bind:animation-duration="animationDuration"
                 v-bind:options-items="optionsItems"
             />

--- a/vue/components/ui/atoms/image-item/image-item.stories.js
+++ b/vue/components/ui/atoms/image-item/image-item.stories.js
@@ -27,7 +27,7 @@ storiesOf("Components/Atoms/Image Item", module)
                 default: boolean("Highlight", false)
             },
             animationDuration: {
-                default: number("Animation Duration", 3000)
+                default: number("Animation Duration", 2000)
             },
             textAlign: {
                 default: select(

--- a/vue/components/ui/atoms/image-item/image-item.vue
+++ b/vue/components/ui/atoms/image-item/image-item.vue
@@ -136,7 +136,7 @@
 @keyframes highlight-image {
 
     0% {
-        background-color: rgba(205, 255, 210, 0.3);
+        background-color: #aeffe2;
     }
 
     100% {
@@ -213,7 +213,7 @@ export const ImageItem = {
          */
         animationDuration: {
             type: Number,
-            default: 3000
+            default: 2000
         }
     },
     data: function() {

--- a/vue/components/ui/atoms/image-item/image-item.vue
+++ b/vue/components/ui/atoms/image-item/image-item.vue
@@ -38,12 +38,12 @@
         </div>
         <div
             class="item-image"
-            v-bind:style="style"
+            v-bind:style="imageStyle"
             v-bind:class="{ 'dropdown-open': optionsVisible }"
             ref="image"
             v-on:animationend="onAnimationEnd"
         >
-            <image-ripe v-bind:style="style" v-bind:src="imageUrl" v-bind:alt="name" />
+            <image-ripe v-bind:style="imageStyle" v-bind:src="imageUrl" v-bind:alt="name" />
         </div>
         <div class="item-text" v-bind:style="nameStyle" v-if="name">
             <div class="name">
@@ -221,7 +221,7 @@ export const ImageItem = {
         optionsScopedSlots() {
             return Object.keys(this.$scopedSlots).filter(slot => slot.startsWith("options-"));
         },
-        style() {
+        imageStyle() {
             const base = {};
             if (this.height) base.height = `${this.height}px`;
             if (this.width) base.width = `${this.width}px`;

--- a/vue/components/ui/atoms/image-item/image-item.vue
+++ b/vue/components/ui/atoms/image-item/image-item.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="image-item" v-bind:class="classes" v-on:click="onClick">
+    <div class="image-item" v-on:click="onClick">
         <div class="item-button" v-on:click.stop>
             <button-icon
                 v-bind:size="32"
@@ -40,9 +40,10 @@
             class="item-image"
             v-bind:style="style"
             v-bind:class="{ 'dropdown-open': optionsVisible }"
+            ref="image"
             v-on:animationend="onAnimationEnd"
         >
-            <image-ripe v-bind:style="imageStyle" v-bind:src="imageUrl" v-bind:alt="name" />
+            <image-ripe v-bind:style="style" v-bind:src="imageUrl" v-bind:alt="name" />
         </div>
         <div class="item-text" v-bind:style="nameStyle" v-if="name">
             <div class="name">
@@ -110,11 +111,6 @@
     width: 200px;
 }
 
-.image-item.highlight > .item-image {
-    animation-name: highlight-image;
-    animation-timing-function: linear;
-}
-
 .image-item > .item-text {
     margin-top: 10px;
     width: 214px;
@@ -131,17 +127,6 @@
     font-size: 14px;
     font-weight: 400;
     margin-top: 5px;
-}
-
-@keyframes highlight-image {
-
-    0% {
-        background-color: #aeffe2;
-    }
-
-    100% {
-        background-color: #f9fafd;
-    }
 }
 </style>
 
@@ -209,6 +194,13 @@ export const ImageItem = {
             default: false
         },
         /**
+         * The background color of the highlight animation.
+         */
+        highlightColor: {
+            type: String,
+            default: "#aeffe2"
+        },
+        /**
          * The duration of the highlight animation.
          */
         animationDuration: {
@@ -229,19 +221,7 @@ export const ImageItem = {
         optionsScopedSlots() {
             return Object.keys(this.$scopedSlots).filter(slot => slot.startsWith("options-"));
         },
-        classes() {
-            const base = {};
-            base.highlight = this.highlightData;
-            return base;
-        },
         style() {
-            const base = {};
-            if (this.highlightData) base["animation-duration"] = `${this.animationDuration}ms`;
-            if (this.height) base.height = `${this.height}px`;
-            if (this.width) base.width = `${this.width}px`;
-            return base;
-        },
-        imageStyle() {
             const base = {};
             if (this.height) base.height = `${this.height}px`;
             if (this.width) base.width = `${this.width}px`;
@@ -260,6 +240,17 @@ export const ImageItem = {
         },
         highlightData(value) {
             this.$emit("update:highlight", value);
+            if (!value) return;
+
+            // animates the image background with the
+            // highlight animation with the given
+            // color and timing
+            this.$refs.image.animate(
+                {
+                    backgroundColor: [this.highlightColor, "#f9fafd"]
+                },
+                this.animationDuration
+            );
         }
     },
     methods: {

--- a/vue/components/ui/molecules/image-list/image-list.stories.js
+++ b/vue/components/ui/molecules/image-list/image-list.stories.js
@@ -64,7 +64,7 @@ storiesOf("Components/Molecules/Image List", module)
             },
             animationDuration: {
                 type: Number,
-                default: number("Animation Duration", 3000)
+                default: number("Animation Duration", 2000)
             },
             textAlign: {
                 default: select(

--- a/vue/components/ui/molecules/image-list/image-list.stories.js
+++ b/vue/components/ui/molecules/image-list/image-list.stories.js
@@ -1,5 +1,5 @@
 import { storiesOf } from "@storybook/vue";
-import { withKnobs, number, select } from "@storybook/addon-knobs";
+import { withKnobs, number, text, select } from "@storybook/addon-knobs";
 
 storiesOf("Components/Molecules/Image List", module)
     .addDecorator(withKnobs)
@@ -59,11 +59,12 @@ storiesOf("Components/Molecules/Image List", module)
                 default: number("Item Width", null)
             },
             highlightIndex: {
-                type: Number,
                 default: number("Highlight Index", undefined)
             },
+            highlightColor: {
+                default: text("Highlight Color", "#aeffe2")
+            },
             animationDuration: {
-                type: Number,
                 default: number("Animation Duration", 2000)
             },
             textAlign: {
@@ -100,6 +101,7 @@ storiesOf("Components/Molecules/Image List", module)
                 v-bind:item-width="itemWidth"
                 v-bind:text-align="textAlign"
                 v-bind:highlight-index="highlightIndex"
+                v-bind:highlight-color="highlightColor"
                 v-bind:animation-duration="animationDuration"
                 v-bind:options-items="optionsItems"
                 v-on:click:option:item_1="onItemClick"

--- a/vue/components/ui/molecules/image-list/image-list.vue
+++ b/vue/components/ui/molecules/image-list/image-list.vue
@@ -86,7 +86,7 @@ export const ImageList = {
          */
         animationDuration: {
             type: Number,
-            default: 3000
+            default: 2000
         }
     },
     computed: {

--- a/vue/components/ui/molecules/image-list/image-list.vue
+++ b/vue/components/ui/molecules/image-list/image-list.vue
@@ -5,6 +5,7 @@
             v-bind:name="item.name"
             v-bind:description="item.description"
             v-bind:highlight="highlightIndex === index"
+            v-bind:highlight-color="highlightColor"
             v-bind:animation-duration="animationDuration"
             v-bind="options(item)"
             v-for="(item, index) in items"
@@ -80,6 +81,13 @@ export const ImageList = {
         highlightIndex: {
             type: Number,
             default: null
+        },
+        /**
+         * The background color of the highlight animation.
+         */
+        highlightColor: {
+            type: String,
+            default: "#aeffe2"
         },
         /**
          * The duration of the highlight animation.


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-twitch/issues/42#issuecomment-806548905 |
| Dependencies | -- |
| Decisions | Fix highlight color, to make it match the design (the previous color was the color if the hover effect is active, giving it less opacity). Also fixed the default timings, making them match the timings given to the, for example, the notification timeout in entity-show. The original timing was a bit too long. |
| Testing | https://ripe-components-vue-git-ms-fix-image-item-highlight-platforme.vercel.app/?path=/story/components-atoms-image-item--image-item |
| Animated GIF |![fix-highlight-story](https://user-images.githubusercontent.com/25725586/112607562-42215100-8e11-11eb-922d-c1780ec7b6ff.gif)<br>![fix-highlight](https://user-images.githubusercontent.com/25725586/112607338-025a6980-8e11-11eb-9ac3-fd371704cda6.gif)|
