### PR TITLE
fix: image-item highlight if true when mounted

### DIFF
--- a/vue/components/ui/atoms/image-item/image-item.vue
+++ b/vue/components/ui/atoms/image-item/image-item.vue
@@ -245,8 +245,9 @@ export const ImageItem = {
         }
     },
     mounted: function() {
-        if (!this.highlightData) return;
-        this.animate();
+        // trigger the highlight animation
+        // if needed
+        if (this.highlightData) this.animate();
     },
     methods: {
         animate() {

--- a/vue/components/ui/atoms/image-item/image-item.vue
+++ b/vue/components/ui/atoms/image-item/image-item.vue
@@ -241,7 +241,15 @@ export const ImageItem = {
         highlightData(value) {
             this.$emit("update:highlight", value);
             if (!value) return;
-
+            this.animate();
+        }
+    },
+    mounted: function() {
+        if (!this.highlightData) return;
+        this.animate();
+    },
+    methods: {
+        animate() {
             // animates the image background with the
             // highlight animation with the given
             // color and timing
@@ -251,9 +259,7 @@ export const ImageItem = {
                 },
                 this.animationDuration
             );
-        }
-    },
-    methods: {
+        },
         onAnimationEnd() {
             this.highlightData = false;
         },

--- a/vue/components/ui/atoms/image-item/image-item.vue
+++ b/vue/components/ui/atoms/image-item/image-item.vue
@@ -245,8 +245,8 @@ export const ImageItem = {
         }
     },
     mounted: function() {
-        // trigger the highlight animation
-        // if needed
+        // triggers the highlight animation if needed
+        // meaning that the highlight reaction is enabled
         if (this.highlightData) this.animate();
     },
     methods: {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-twitch/issues/84#issuecomment-811251719<br>When the `highlight` prop was true when the component first mounted, the animation did not occur. This occured in `twitch-admin-ui` after going from white to admin-ui, where the first image-item was mounted with the highlight at `true` but the animation did not occur. |
| Dependencies | |
| Decisions | Play the animation when the component is first mounted (if `highlightData` is `true`). Done on mounted because it needs the `$refs.image` to be populated. Extracted animation logic to method. |
| Animated GIF | -- |
