### PR TITLE
fix: search bar uses all width in mobile

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,12 +63,12 @@
         "yonius": "^0.7.6"
     },
     "devDependencies": {
-        "@storybook/addon-knobs": "^6.2.0",
-        "@storybook/addon-storysource": "^6.2.0",
-        "@storybook/source-loader": "^6.2.0",
-        "@storybook/vue": "^6.2.0",
-        "@vue/test-utils": "^1.1.3",
-        "jsdom": "^16.5.2",
+        "@storybook/addon-knobs": "^6.2.7",
+        "@storybook/addon-storysource": "^6.2.7",
+        "@storybook/source-loader": "^6.2.7",
+        "@storybook/vue": "^6.2.7",
+        "@vue/test-utils": ">=1.1.0 <=1.1.3",
+        "jsdom": "^16.5.3",
         "jsdom-global": "^3.0.2",
         "mocha": "^8.3.2",
         "mochapack": "^2.0.6",
@@ -76,7 +76,7 @@
         "null-loader": "^4.0.1",
         "svgo": "^2.3.0",
         "url-loader": "^4.1.1",
-        "uxf-webpack": "^0.8.4",
+        "uxf-webpack": "^0.8.7",
         "vue-loader": "^15.9.6"
     },
     "engines": {

--- a/package.json
+++ b/package.json
@@ -63,12 +63,12 @@
         "yonius": "^0.7.6"
     },
     "devDependencies": {
-        "@storybook/addon-knobs": "^6.2.7",
-        "@storybook/addon-storysource": "^6.2.7",
-        "@storybook/source-loader": "^6.2.7",
-        "@storybook/vue": "^6.2.7",
-        "@vue/test-utils": ">=1.1.0 <=1.1.3",
-        "jsdom": "^16.5.3",
+        "@storybook/addon-knobs": "^6.2.0",
+        "@storybook/addon-storysource": "^6.2.0",
+        "@storybook/source-loader": "^6.2.0",
+        "@storybook/vue": "^6.2.0",
+        "@vue/test-utils": "^1.1.3",
+        "jsdom": "^16.5.2",
         "jsdom-global": "^3.0.2",
         "mocha": "^8.3.2",
         "mochapack": "^2.0.6",

--- a/vue/components/ui/organisms/listing/listing.vue
+++ b/vue/components/ui/organisms/listing/listing.vue
@@ -234,6 +234,7 @@ body.mobile .listing {
 
 .listing .container-ripe .tooltip.tooltip-mobile {
     margin-bottom: 16px;
+    width: 100%;
 }
 
 .listing .container-ripe .search.search-mobile {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-pulse/issues/194 |
| Dependencies | |
| Decisions | Like the [design](https://www.figma.com/file/yA0m9ZpxJUeQkOZXjvVtiM/ripe-pulse?node-id=0%3A8030), in mobile mode the search occupies all width and appear above the container title. |
| Problems | The new release [1.1.4 of vue test-utils](https://github.com/vuejs/vue-test-utils/issues/1820) introduced some regressions which caused the `select` to start failing. Issues about the regression: https://github.com/vuejs/vue-test-utils/issues/1820 & https://github.com/vuejs/vue-test-utils/pull/1808 (the PR that possibly caused this regression) | 
| Animated GIF | ![image](https://user-images.githubusercontent.com/25725586/114416713-ded14600-9ba8-11eb-98c7-1dfce9f9ea33.png)|
