### PR TITLE
fix: lock vue-test-utils version

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
         "@storybook/addon-storysource": "^6.2.0",
         "@storybook/source-loader": "^6.2.0",
         "@storybook/vue": "^6.2.0",
-        "@vue/test-utils": "^1.1.3",
+        "@vue/test-utils": ">1.0.0 && <=1.1.3",
         "jsdom": "^16.5.2",
         "jsdom-global": "^3.0.2",
         "mocha": "^8.3.2",


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | CI is failing due to regressions in vue-test-utils 1.1.4 version. A PR is opened but still not addressed: https://github.com/vuejs/vue-test-utils/pull/1826 |
| Dependencies | -- |
| Decisions | Lock version to 1.1.3 or below. Similar to ripe-white. |
| Animated GIF | -- |
