### PR TITLE
Image Item: fix image fit

### DIFF
--- a/vue/components/ui/atoms/image-item/image-item.vue
+++ b/vue/components/ui/atoms/image-item/image-item.vue
@@ -108,7 +108,6 @@
 
 .image-item > .item-image > .image {
     height: 200px;
-    object-fit: contain;
     width: 200px;
 }
 
@@ -171,6 +170,14 @@ export const ImageItem = {
             default: null
         },
         /**
+         * The object fit of the image. Sets how the content
+         * should be resized to fit its container.
+         */
+        imageObjectFit: {
+            type: String,
+            default: "contain"
+        },
+        /**
          * The name text alignment.
          */
         textAlign: {
@@ -226,6 +233,7 @@ export const ImageItem = {
             const base = {};
             if (this.height) base.height = `${this.height}px`;
             if (this.width) base.width = `${this.width}px`;
+            if (this.imageObjectFit) base.objectFit = this.imageObjectFit;
             return base;
         },
         nameStyle() {

--- a/vue/components/ui/atoms/image-item/image-item.vue
+++ b/vue/components/ui/atoms/image-item/image-item.vue
@@ -108,6 +108,7 @@
 
 .image-item > .item-image > .image {
     height: 200px;
+    object-fit: contain;
     width: 200px;
 }
 

--- a/vue/components/ui/molecules/image-list/image-list.vue
+++ b/vue/components/ui/molecules/image-list/image-list.vue
@@ -6,6 +6,7 @@
             v-bind:description="item.description"
             v-bind:highlight="highlightIndex === index"
             v-bind:highlight-color="highlightColor"
+            v-bind:image-object-fit="item.objectFit"
             v-bind:animation-duration="animationDuration"
             v-bind="options(item)"
             v-for="(item, index) in items"


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Image becomes undesirably stretched in case the image source isn't 1:1 width:height ratio.  |
| Decisions | Using [object-fit contain](https://developer.mozilla.org/pt-BR/docs/Web/CSS/object-fit#syntax). |
| Animated GIF | Below |
### Before
![image](https://user-images.githubusercontent.com/24736423/116528372-abdec000-a8d3-11eb-9d7e-909c3c9c8998.png)

### After
![image](https://user-images.githubusercontent.com/24736423/116528276-8ce02e00-a8d3-11eb-8ff5-f29443d5d29d.png)

