### PR TITLE
feat: better default labels for select-checkboxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Support for `debug` widget
 * Global state object exposed
 * `All` options in `select-checkboxes`
+* Better default label in `select-checkboxes`
 
 ### Changed
 

--- a/vue/components/ui/molecules/select-checkboxes/select-checkboxes.stories.js
+++ b/vue/components/ui/molecules/select-checkboxes/select-checkboxes.stories.js
@@ -5,8 +5,14 @@ storiesOf("Components/Molecules/Select Checkboxes", module)
     .addDecorator(withKnobs)
     .add("Select Checkboxes", () => ({
         props: {
+            placeholder: {
+                default: text("Placeholder", null)
+            },
             label: {
-                default: text("Label", "Label Example")
+                default: text("Label", "Label")
+            },
+            labelSeparator: {
+                default: text("Label Separator", " / ")
             },
             showAll: {
                 default: boolean("Show All", false)
@@ -71,7 +77,9 @@ storiesOf("Components/Molecules/Select Checkboxes", module)
         template: `
             <div>
                 <select-checkboxes
+                    v-bind:placeholder="placeholder"
                     v-bind:label="label"
+                    v-bind:label-separator="labelSeparator"
                     v-bind:show-all="showAll"
                     v-bind:all-label="allLabel"
                     v-bind:all-value="allValue"

--- a/vue/components/ui/molecules/select-checkboxes/select-checkboxes.vue
+++ b/vue/components/ui/molecules/select-checkboxes/select-checkboxes.vue
@@ -43,11 +43,27 @@ export const SelectCheckboxes = {
     name: "select-checkboxes",
     props: {
         /**
+         * Placeholder shown in the select button
+         * when no options are selected.
+         */
+        placeholder: {
+            type: String,
+            default: null
+        },
+        /**
          * Label shown in the select button.
          */
         label: {
             type: String,
-            required: true
+            default: null
+        },
+        /**
+         * The separator to use when building the label
+         * consisting of the selected values.
+         */
+        labelSeparator: {
+            type: String,
+            default: " / "
         },
         /**
          * Checkbox group items.
@@ -110,7 +126,16 @@ export const SelectCheckboxes = {
     },
     computed: {
         selectOptions() {
-            return [{ label: this.label, value: "checkbox-group" }];
+            return [{ label: this._label, value: "checkbox-group" }];
+        },
+        _label() {
+            if (this.label) return this.label;
+            if (this.allSelected) return this.allLabel;
+            const selectedLabels = this.items
+                .filter(item => this.valuesData[item.value])
+                .map(item => item.label || item.value);
+            if (selectedLabels.length === 0) return this.placeholder;
+            return selectedLabels.join(this.labelSeparator);
         },
         _items() {
             if (!this.showAll) return this.items;


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Motivated several ad-hoc implementations (e.g. ripe-tech/ripe-util-vue#53) that did the same over and over. |
| Dependencies | https://github.com/ripe-tech/ripe-components-vue/pull/484 |
| Animated GIF | ![](http://g.recordit.co/z8LrZWXDVc.gif) |
