### PR TITLE
#60 Add image list and imagem item slots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Global state object exposed
 * `All` options in `select-checkboxes`
 * Better default label in `select-checkboxes`
+* Support for slot pass through in `image-list`
+* Add slot for name label in `image-item`
 
 ### Changed
 

--- a/vue/components/ui/atoms/image-item/image-item.vue
+++ b/vue/components/ui/atoms/image-item/image-item.vue
@@ -46,9 +46,11 @@
             <image-ripe v-bind:style="imageStyle" v-bind:src="imageUrl" v-bind:alt="name" />
         </div>
         <div class="item-text" v-bind:style="nameStyle" v-if="name">
-            <div class="name">
-                {{ name }}
-            </div>
+            <slot name="name">
+                <div class="name">
+                    {{ name }}
+                </div>
+            </slot>
             <slot name="description">
                 <div class="description">
                     {{ description }}

--- a/vue/components/ui/molecules/image-list/image-list.vue
+++ b/vue/components/ui/molecules/image-list/image-list.vue
@@ -15,7 +15,16 @@
             v-on:click:button="event => onButtonClick(event, item, index)"
             v-on:update:highlight="value => onUpdateHighlight(item, index, value)"
             v-on="listeners"
-        />
+        >
+            <slot v-bind:name="slot" v-for="slot in Object.keys($slots)" v-bind:slot="slot" />
+            <template
+                v-for="slot in Object.keys($scopedSlots)"
+                v-bind:slot="slot"
+                slot-scope="scope"
+            >
+                <slot v-bind:name="slot" v-bind="scope" v-bind:item="item" />
+            </template>
+        </image-item>
     </div>
 </template>
 


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-util-vue/issues/60 |
| Decisions | Add slot to allow the override of `name` field. In the context of the issue it will allow the addiction of the review buttons. |
| Animated GIF | ![image](https://user-images.githubusercontent.com/24736423/116890814-ef179680-ac25-11eb-82c0-b49cf32e2f44.png) |
