### PR TITLE
Image list: Option to use id as a key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* Optionally using `item.id` as item key in `image-list`
 
 ### Changed
 

--- a/vue/components/ui/molecules/image-list/image-list.vue
+++ b/vue/components/ui/molecules/image-list/image-list.vue
@@ -10,7 +10,7 @@
             v-bind:animation-duration="animationDuration"
             v-bind="options(item)"
             v-for="(item, index) in items"
-            v-bind:key="index"
+            v-bind:key="item.key || index"
             v-on:click="event => onClick(event, item, index)"
             v-on:click:button="event => onButtonClick(event, item, index)"
             v-on:update:highlight="value => onUpdateHighlight(item, index, value)"

--- a/vue/components/ui/molecules/image-list/image-list.vue
+++ b/vue/components/ui/molecules/image-list/image-list.vue
@@ -10,7 +10,7 @@
             v-bind:animation-duration="animationDuration"
             v-bind="options(item)"
             v-for="(item, index) in items"
-            v-bind:key="item.key || index"
+            v-bind:key="item.id || index"
             v-on:click="event => onClick(event, item, index)"
             v-on:click:button="event => onButtonClick(event, item, index)"
             v-on:update:highlight="value => onUpdateHighlight(item, index, value)"


### PR DESCRIPTION
| - | - |
| --- | --- |
| Decisions | Optionally using `item.id` as key. This fixes the problem when the items change but the index is the same. We're also using this pattern in other components e.g. `<table>`. |
