### PR TITLE
feat: added header prop

### DIFF
--- a/vue/components/ui/organisms/input-list/input-list.stories.js
+++ b/vue/components/ui/organisms/input-list/input-list.stories.js
@@ -1,5 +1,5 @@
 import { storiesOf } from "@storybook/vue";
-import { select } from "@storybook/addon-knobs";
+import { boolean, select } from "@storybook/addon-knobs";
 
 storiesOf("Components/Organisms/Input List", module).add("Input List", () => ({
     props: {
@@ -42,6 +42,9 @@ storiesOf("Components/Organisms/Input List", module).add("Input List", () => ({
                 },
                 "top"
             )
+        },
+        header: {
+            default: boolean("Header", true)
         }
     },
     data: function() {
@@ -55,6 +58,7 @@ storiesOf("Components/Organisms/Input List", module).add("Input List", () => ({
                 v-bind:fields="fields"
                 v-bind:values.sync="values"
                 v-bind:button-add-row="buttonAddRow"
+                v-bind:header="header"
             />
             <p> Values: {{ values }} </p>
         </div>

--- a/vue/components/ui/organisms/input-list/input-list.vue
+++ b/vue/components/ui/organisms/input-list/input-list.vue
@@ -1,9 +1,10 @@
 <template>
     <div class="input-list">
-        <div class="list-header" v-if="header">
+        <div class="list-header" v-if="headerVisibility">
             <div
                 v-bind:class="`label ${field.value}`"
                 v-for="field in fieldLabels"
+                v-show="header"
                 v-bind:key="field.value"
             >
                 {{ field.label === undefined ? field.value : field.label }}
@@ -157,9 +158,12 @@ export const InputList = {
         };
     },
     computed: {
+        headerVisibility() {
+            return this.buttonAddRow === "top" || this.header;
+        },
         buttonContainerStyle() {
             const base = {};
-            if (this.buttonAddRow === "top" && this.header) {
+            if (this.buttonAddRow === "top") {
                 base.position = "absolute";
                 base.top = "7px";
                 base.right = "0px";

--- a/vue/components/ui/organisms/input-list/input-list.vue
+++ b/vue/components/ui/organisms/input-list/input-list.vue
@@ -10,7 +10,7 @@
                 {{ field.label === undefined ? field.value : field.label }}
             </div>
         </div>
-        <div class="list-content">
+        <div class="list-content" v-bind:class="listContentClasses">
             <div class="list-row" v-for="(row, index) in valuesData" v-bind:key="row.value">
                 <div
                     v-bind:class="`field ${field.value}`"
@@ -68,6 +68,7 @@
 
 .input-list .list-header {
     align-items: center;
+    border-bottom: 1px solid #e4e8f0;
     display: flex;
     font-size: 12px;
     height: 40px;
@@ -91,8 +92,11 @@
     min-width: 30px;
 }
 
+.list-content.add-row-button-top .list-row:last-child {
+    border-bottom: none;
+}
+
 .input-list .list-content {
-    border-top: 1px solid #e4e8f0;
     display: block;
     padding: 0px 0px 5px 0px;
 }
@@ -158,8 +162,10 @@ export const InputList = {
         };
     },
     computed: {
-        headerVisibility() {
-            return this.buttonAddRow === "top" || this.header;
+        listContentClasses() {
+            const base = {};
+            if (this.buttonAddRow === "top") base["add-row-button-top"] = true;
+            return base;
         },
         buttonContainerStyle() {
             const base = {};
@@ -172,6 +178,9 @@ export const InputList = {
         },
         fieldLabels() {
             return [...this.fields, { value: "action-buttons", label: null }];
+        },
+        headerVisibility() {
+            return this.buttonAddRow === "top" || this.header;
         }
     },
     watch: {

--- a/vue/components/ui/organisms/input-list/input-list.vue
+++ b/vue/components/ui/organisms/input-list/input-list.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="input-list">
-        <div class="list-header">
+        <div class="list-header" v-if="header">
             <div
                 v-bind:class="`label ${field.value}`"
                 v-for="field in fieldLabels"
@@ -145,6 +145,10 @@ export const InputList = {
         buttonAddRow: {
             type: String,
             default: "top"
+        },
+        header: {
+            type: Boolean,
+            default: true
         }
     },
     data: function() {
@@ -155,7 +159,7 @@ export const InputList = {
     computed: {
         buttonContainerStyle() {
             const base = {};
-            if (this.buttonAddRow === "top") {
+            if (this.buttonAddRow === "top" && this.header) {
                 base.position = "absolute";
                 base.top = "7px";
                 base.right = "0px";

--- a/vue/components/ui/organisms/input-list/input-list.vue
+++ b/vue/components/ui/organisms/input-list/input-list.vue
@@ -92,10 +92,6 @@
     min-width: 30px;
 }
 
-.list-content.add-row-button-top .list-row:last-child {
-    border-bottom: none;
-}
-
 .input-list .list-content {
     display: block;
     padding: 0px 0px 5px 0px;
@@ -109,6 +105,10 @@
 
 .input-list .list-content .list-row:hover {
     background-color: #f8f8f8;
+}
+
+.input-list .list-content.add-row-button-top .list-row:last-child {
+    border-bottom: none;
 }
 
 .input-list .list-content .list-row .field {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Decisions | Added prop to control header visibility. Defaults to "true". If header is de-selected and the add button position is "top", it automatically sets it to the bottom. |
| Animated GIF | |

With the header:
![image](https://user-images.githubusercontent.com/22790704/118112675-3bf52d00-b3dd-11eb-9fe2-dcf834ce3990.png)

Without the header:
![image](https://user-images.githubusercontent.com/22790704/118112784-60e9a000-b3dd-11eb-910e-8a30e425ac1e.png)
