### PR TITLE
Accepting numbers in value prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* Support for `Number` type values in `radio`, `radio-group` and `select`
 
 ### Changed
 

--- a/vue/components/ui/atoms/radio/radio.vue
+++ b/vue/components/ui/atoms/radio/radio.vue
@@ -106,7 +106,7 @@ export const Radio = {
             default: null
         },
         value: {
-            type: String,
+            type: String | Number,
             default: null
         },
         checked: {

--- a/vue/components/ui/molecules/radio-group/radio-group.vue
+++ b/vue/components/ui/molecules/radio-group/radio-group.vue
@@ -52,7 +52,7 @@ export const RadioGroup = {
             default: () => []
         },
         value: {
-            type: String,
+            type: String | Number,
             default: null
         },
         disabled: {

--- a/vue/components/ui/molecules/select/select.vue
+++ b/vue/components/ui/molecules/select/select.vue
@@ -160,7 +160,7 @@ export const Select = {
             default: () => []
         },
         value: {
-            type: String,
+            type: String | Number,
             default: null
         },
         visible: {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | There's a restriction for the prop value to be `String` only type in some components. This might be a hassle for some data sources that could be defined to using native number values .e.g a select with values `[{ label: "One", value: 1 }]` and having to add extra logic to cast and uncast in computed variables when the component could simply accept and emit the native value as is. Note that we're [already doing this](https://github.com/ripe-tech/ripe-components-vue/blob/master/vue/components/ui/atoms/input/input.vue#L97) in `<input>` |
| Decisions | - Extend https://github.com/ripe-tech/ripe-components-vue/pull/136 fix to other components. This also fixes some warn messages for some implementations when the number isn't casted to `String`. |
