### PR TITLE
fix: fix upload area component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-* Clear the value of the input on buttonClick
+* Clear the value of the input on when 'files' prop is null or empty
 
 ## [0.9.5] - 2021-05-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-*
+* Clear the value of the input on buttonClick
 
 ## [0.9.5] - 2021-05-19
 

--- a/vue/components/ui/molecules/upload-area/upload-area.vue
+++ b/vue/components/ui/molecules/upload-area/upload-area.vue
@@ -161,7 +161,7 @@ export const UploadArea = {
     },
     watch: {
         files(value) {
-            if (!value || value.length === 0) this._clearInput();
+            if (!value || value.length === 0) this.clear();
             this.filesData = value;
         },
         dragging(value) {
@@ -173,7 +173,7 @@ export const UploadArea = {
             this.filesData = [...filesList];
             this.$emit("update:files", this.filesData);
         },
-        _clearInput() {
+        clear() {
             this.$refs.filesInput.value = null;
         },
         openModal() {

--- a/vue/components/ui/molecules/upload-area/upload-area.vue
+++ b/vue/components/ui/molecules/upload-area/upload-area.vue
@@ -161,7 +161,7 @@ export const UploadArea = {
     },
     watch: {
         files(value) {
-            if (!value) this._clearInput();
+            if (!value || value.length === 0) this._clearInput();
             this.filesData = value;
         },
         dragging(value) {

--- a/vue/components/ui/molecules/upload-area/upload-area.vue
+++ b/vue/components/ui/molecules/upload-area/upload-area.vue
@@ -173,6 +173,9 @@ export const UploadArea = {
             this.filesData = [...filesList];
             this.$emit("update:files", this.filesData);
         },
+        _clearInput() {
+            this.$refs.filesInput.value = null;
+        },
         openModal() {
             this.$refs.filesInput.click();
         },
@@ -202,9 +205,6 @@ export const UploadArea = {
         },
         onUploadButtonClick() {
             this.$refs.filesInput.click();
-        },
-        _clearInput() {
-            this.$refs.filesInput.value = null;
         }
     }
 };

--- a/vue/components/ui/molecules/upload-area/upload-area.vue
+++ b/vue/components/ui/molecules/upload-area/upload-area.vue
@@ -161,6 +161,7 @@ export const UploadArea = {
     },
     watch: {
         files(value) {
+            if (!value) this._clearInput();
             this.filesData = value;
         },
         dragging(value) {
@@ -168,9 +169,6 @@ export const UploadArea = {
         }
     },
     methods: {
-        clear() {
-            this.$refs.filesInput.value = null;
-        },
         setFiles(filesList) {
             this.filesData = [...filesList];
             this.$emit("update:files", this.filesData);
@@ -203,8 +201,10 @@ export const UploadArea = {
             this.setFiles(this.$refs.filesInput.files);
         },
         onUploadButtonClick() {
-            this.clear();
             this.$refs.filesInput.click();
+        },
+        _clearInput() {
+            this.$refs.filesInput.value = null;
         }
     }
 };


### PR DESCRIPTION
| - | - |
| --- | --- |
| Decisions | This was originated by a behaviour found in [rules uploader utility](https://github.com/ripe-tech/ripe-util/issues/72) that prevented normal functionality. If for some reason the parent component discard the selected file [sent by upload-area](https://github.com/ripe-tech/ripe-components-vue/blob/f25c04a26a9266d387c7fca9f695f0bfdc3879bf/vue/components/ui/molecules/upload-area/upload-area.vue#L173) and would want to grab the file again, on file selection, the upload-area component would still have the file selected, the event would not get triggered. because the component would not seet it as a change So, with other approaches less "cirurgical", I decided to clear the input on buttonclick |
| Animated GIF | With fix ![j5Ite5qf5F](https://user-images.githubusercontent.com/8842023/119678543-85129b80-be37-11eb-9976-a4672242c601.gif) Without fix ![UI4pOpzzG9](https://user-images.githubusercontent.com/8842023/119679009-edfa1380-be37-11eb-8bf9-9b21f64814d0.gif)|

