### PR TITLE
feat: container header buttons type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `select` new `inline` prop
 * `inline` mode for `container-ripe` and `listing`
 * `container-ripe` new `overflow` props
+* `type` for `container-ripe` header buttons
 
 ### Changed
 

--- a/vue/components/ui/atoms/container/container.stories.js
+++ b/vue/components/ui/atoms/container/container.stories.js
@@ -46,6 +46,12 @@ storiesOf("Components/Atoms/Container", module)
                         loading: true
                     },
                     {
+                        id: "create",
+                        text: "Create",
+                        icon: "add",
+                        type: "color"
+                    },
+                    {
                         id: "notshow",
                         text: "Not showing",
                         icon: "eye",

--- a/vue/components/ui/atoms/container/container.vue
+++ b/vue/components/ui/atoms/container/container.vue
@@ -21,8 +21,8 @@
                                 class="header-button"
                                 v-bind="button"
                                 v-show="!button.hide"
-                                v-bind:key="button.id"
                                 v-if="button.type === undefined || button.type === 'icon'"
+                                v-bind:key="button.id"
                                 v-on:click="event => onHeaderButtonClick(event, button.id)"
                             />
                             <button-color
@@ -32,8 +32,8 @@
                                 v-bind:min-width="0"
                                 v-bind="button"
                                 v-show="!button.hide"
-                                v-bind:key="button.id"
                                 v-else-if="button.type === 'color'"
+                                v-bind:key="button.id"
                                 v-on:click="event => onHeaderButtonClick(event, button.id)"
                             />
                         </template>

--- a/vue/components/ui/atoms/container/container.vue
+++ b/vue/components/ui/atoms/container/container.vue
@@ -16,30 +16,27 @@
                 <slot name="header-buttons" v-if="hasHeaderButtons">
                     <div class="header-buttons">
                         <slot name="header-buttons-inside-before" />
-                        <button-icon
-                            class="header-button"
-                            v-bind:text="button.text"
-                            v-bind:icon="button.icon"
-                            v-bind:color="button.color"
-                            v-bind:size="button.size"
-                            v-bind:icon-opacity="button.iconOpacity"
-                            v-bind:icon-fill="button.iconFill"
-                            v-bind:icon-stroke-width="button.iconStrokeWidth"
-                            v-bind:padding="button.padding"
-                            v-bind:padding-top="button.paddingTop"
-                            v-bind:padding-bottom="button.paddingBottom"
-                            v-bind:padding-left="button.paddingLeft"
-                            v-bind:padding-right="button.paddingRight"
-                            v-bind:padding-factor="button.paddingFactor"
-                            v-bind:padding-text-factor="button.paddingTextFactor"
-                            v-bind:disabled="button.disabled"
-                            v-bind:selectable="button.selectable"
-                            v-bind:loading="button.loading"
-                            v-for="button in headerButtons"
-                            v-show="!button.hide"
-                            v-bind:key="button.id"
-                            v-on:click="event => onButtonIconClick(event, button.id)"
-                        />
+                        <template v-for="button in headerButtons">
+                            <button-icon
+                                class="header-button"
+                                v-bind="button"
+                                v-show="!button.hide"
+                                v-bind:key="button.id"
+                                v-if="button.type === undefined || button.type === 'icon'"
+                                v-on:click="event => onHeaderButtonClick(event, button.id)"
+                            />
+                            <button-color
+                                class="header-button"
+                                v-bind:size="'small'"
+                                v-bind:alignment="'left'"
+                                v-bind:min-width="0"
+                                v-bind="button"
+                                v-show="!button.hide"
+                                v-bind:key="button.id"
+                                v-else-if="button.type === 'color'"
+                                v-on:click="event => onHeaderButtonClick(event, button.id)"
+                            />
+                        </template>
                         <slot name="header-buttons-inside-after" />
                     </div>
                 </slot>
@@ -222,7 +219,7 @@ export const Container = {
         }
     },
     methods: {
-        onButtonIconClick(event, buttonId) {
+        onHeaderButtonClick(event, buttonId) {
             this.$emit("header-button:click", event, buttonId);
             this.$emit(`header-button:click:${buttonId}`, event);
         }


### PR DESCRIPTION
| - | - |
| --- | --- |
| Decisions | Before this change only button icons were supported. While they remain the default, it should be possible to use other types of buttons.  |
| Animated GIF | ![image](https://user-images.githubusercontent.com/3048875/119681500-08cd8780-be3a-11eb-842d-1f69a42333f9.png) |
