### PR TITLE
Add typeless value support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `inline` mode for `container-ripe` and `listing`
 * `container-ripe` new `overflow` props
 * `type` for `container-ripe` header buttons
+* Support for any type values in `radio`, `radio-group` and `select`
 
 ### Changed
 

--- a/vue/components/ui/atoms/radio/radio.vue
+++ b/vue/components/ui/atoms/radio/radio.vue
@@ -106,7 +106,6 @@ export const Radio = {
             default: null
         },
         value: {
-            type: String | Number,
             default: null
         },
         checked: {

--- a/vue/components/ui/molecules/radio-group/radio-group.vue
+++ b/vue/components/ui/molecules/radio-group/radio-group.vue
@@ -52,7 +52,6 @@ export const RadioGroup = {
             default: () => []
         },
         value: {
-            type: String | Number,
             default: null
         },
         disabled: {

--- a/vue/components/ui/molecules/select/select.vue
+++ b/vue/components/ui/molecules/select/select.vue
@@ -164,7 +164,6 @@ export const Select = {
             default: () => []
         },
         value: {
-            type: String | Number,
             default: null
         },
         visible: {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Currently it's not possible to pass an object as a value in `<select>` prop `options` and components that involves selecting a value from an array of options. |
| Decisions | - Remove type limitation for `<select>` <br> - Back porting might be necessary after acceptance |
