### PR TITLE
Modal: fix title width

### DIFF
--- a/vue/components/ui/molecules/modal/modal.vue
+++ b/vue/components/ui/molecules/modal/modal.vue
@@ -1,6 +1,6 @@
 <template>
     <transition name="fade">
-        <div v-bind:class="['modal', className]" v-show="isVisible" v-bind:id="className">
+        <div class="modal" v-bind:class="classes" v-show="isVisible" v-bind:id="className">
             <global-events v-on:keydown.esc="handleGlobal" />
             <overlay
                 v-bind:class="{ clickable: overlayLeave }"
@@ -161,7 +161,7 @@ body.mobile .modal > .modal-container {
     text-align: left;
 }
 
-.modal > .modal-container > .modal-body > .title.compact {
+.modal.close-button > .modal-container > .modal-body > .title {
     width: calc(100% - 18px);
 }
 
@@ -282,10 +282,11 @@ export const Modal = {
         }
     },
     computed: {
-        titleClasses() {
+        classes() {
             const base = {
-                compact: this.buttonClose
+                "close-button": this.buttonClose
             };
+            if (this.className) base[this.className] = true;
             return base;
         },
         className() {

--- a/vue/components/ui/molecules/modal/modal.vue
+++ b/vue/components/ui/molecules/modal/modal.vue
@@ -159,6 +159,7 @@ body.mobile .modal > .modal-container {
     letter-spacing: 0.5px;
     margin: 0px 0px 12px 0px;
     text-align: left;
+    width: calc(100% - 18px);
 }
 
 .modal > .modal-container > .modal-body > .sub-title {

--- a/vue/components/ui/molecules/modal/modal.vue
+++ b/vue/components/ui/molecules/modal/modal.vue
@@ -23,7 +23,7 @@
                 </div>
                 <div class="modal-body">
                     <slot name="body">
-                        <h1 class="title" v-if="title">{{ title }}</h1>
+                        <h1 class="title" v-bind:class="titleClasses" v-if="title">{{ title }}</h1>
                         <h2 class="sub-title" v-if="subTitle">{{ subTitle }}</h2>
                         <div class="modal-content" ref="content">
                             <slot />
@@ -159,6 +159,9 @@ body.mobile .modal > .modal-container {
     letter-spacing: 0.5px;
     margin: 0px 0px 12px 0px;
     text-align: left;
+}
+
+.modal > .modal-container > .modal-body > .title.compact {
     width: calc(100% - 18px);
 }
 
@@ -279,6 +282,12 @@ export const Modal = {
         }
     },
     computed: {
+        titleClasses() {
+            const base = {
+                compact: this.buttonClose
+            };
+            return base;
+        },
         className() {
             return this.name ? `modal-${this.name}` : null;
         },


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-util-vue/issues/69#issuecomment-861521404 |
| Decisions | - Fix title overlapping close button space by decreasing total space by 18 pixels (space occupied by close button element including padding) |
| Animated GIF | <img width="512" alt="image" src="https://user-images.githubusercontent.com/24736423/122066493-b0f7c000-cdea-11eb-95ff-db8142af397e.png"> |
