### PR TITLE
Resolved input-list bad v-bind

### DIFF
--- a/vue/components/ui/organisms/form/form.vue
+++ b/vue/components/ui/organisms/form/form.vue
@@ -58,7 +58,7 @@
                                     />
                                     <input-list
                                         v-bind="field.props"
-                                        v-bind:value="fromValue(field)"
+                                        v-bind:values="fromValue(field)"
                                         v-else-if="field.type === 'list'"
                                         v-on:update:values="value => onValue(field, value)"
                                     />


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | `v-bind:value=...` should be `v-bind:values=...` |
| Dependencies | -- |
| Decisions | Resolve typo in `v-bind:values` of `input-list` in `form-ripe` |
| Animated GIF | -- |
