### PR TITLE
feat: bump commons dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     },
     "dependencies": {
         "loaders.css": "^0.1.2",
-        "ripe-commons": "^0.4.0",
+        "ripe-commons": "^0.4.1",
         "vue": "^2.6.12",
         "vue-global-events": "^1.2.1",
         "yonius": "^0.7.7"


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-pulse/issues/165 |
| Dependencies | -- |
| Decisions |  Bump commons dependency. After this is merged, `components-vue` needs a release so that I can bump it on rie-pulse. |
| Animated GIF | -- |
