### PR TITLE
fix: word break in alert text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-* word breaking in `alert` component
+* Added word breaking to the alert component, so that the entire text is always visible
 
 ## [0.13.0] - 2021-07-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-*
+* word breaking in `alert` component
 
 ## [0.13.0] - 2021-07-05
 

--- a/vue/components/ui/molecules/alert/alert.vue
+++ b/vue/components/ui/molecules/alert/alert.vue
@@ -59,6 +59,12 @@
     </modal>
 </template>
 
+<style scoped>
+.text {
+    word-break: break-all;
+}
+</style>
+
 <script>
 export const Alert = {
     name: "alert",


### PR DESCRIPTION
| - | - |
| --- | --- |
| Description | Issue detected in while doing https://github.com/ripe-tech/ripe-util/issues/72 |
| Screenshots | Before <br> <img width="802" alt="modal-not" src="https://user-images.githubusercontent.com/8842023/126138900-3f940265-0782-4fef-afbb-125f21b8f890.png"> After <br> <img width="854" alt="modal-yes" src="https://user-images.githubusercontent.com/8842023/126138987-f86997aa-832f-4a78-a381-a587ce26695c.png">|
