### PR TITLE
#125 Select checkboxes can scroll to match when using input

### DIFF
--- a/vue/components/ui/molecules/select-checkboxes/select-checkboxes.vue
+++ b/vue/components/ui/molecules/select-checkboxes/select-checkboxes.vue
@@ -41,11 +41,11 @@
 </style>
 
 <script>
-import { utilsMixin } from "../../../../mixins";
+import { scrollMixin } from "../../../../mixins";
 
 export const SelectCheckboxes = {
     name: "select-checkboxes",
-    mixins: [utilsMixin],
+    mixins: [scrollMixin],
     props: {
         /**
          * Placeholder shown in the select button
@@ -181,13 +181,9 @@ export const SelectCheckboxes = {
             const index = this._items.findIndex(option =>
                 option.label?.toUpperCase().startsWith(keyBuffer)
             );
-
-            if (index === -1) return;
-
             const dropdown = this.$refs.select.$refs.dropdown.$refs.dropdown;
             const dropdownElement = dropdown.getElementsByClassName("dropdown-item")[0];
             const elements = dropdownElement.getElementsByClassName("checkbox-item");
-
             this.scrollToIndex(dropdown, elements, index);
         }
     }

--- a/vue/components/ui/molecules/select-checkboxes/select-checkboxes.vue
+++ b/vue/components/ui/molecules/select-checkboxes/select-checkboxes.vue
@@ -3,11 +3,17 @@
         class="select-checkboxes"
         v-bind:options="selectOptions"
         v-bind:value="'checkbox-group'"
+        v-bind:disabled="disabled"
+        v-bind="{
+            autoScroll: false,
+            maxHeight: 210,
+            ...selectProps
+        }"
         ref="select"
-        v-on:select:keydown="scrollToInput"
+        v-on:select:keydown="scrollToCheckbox"
     >
         <template v-slot:checkbox-group>
-            <div class="checkboxes" ref="checkboxes">
+            <div class="checkboxes" ref="checkboxes" v-on:click.stop>
                 <checkbox-group v-bind:items="_items" v-bind:values.sync="valuesData" />
             </div>
         </template>
@@ -171,7 +177,7 @@ export const SelectCheckboxes = {
         }
     },
     methods: {
-        scrollToInput(keyBuffer) {
+        scrollToCheckbox(_key, keyBuffer) {
             const index = this._items.findIndex(option =>
                 option.label?.toUpperCase().startsWith(keyBuffer)
             );
@@ -182,7 +188,7 @@ export const SelectCheckboxes = {
             const dropdownElement = dropdown.getElementsByClassName("dropdown-item")[0];
             const elements = dropdownElement.getElementsByClassName("checkbox-item");
 
-            this.scrollToIndexDropdown(dropdown, elements, index);
+            this.scrollToIndex(dropdown, elements, index);
         }
     }
 };

--- a/vue/components/ui/molecules/select-checkboxes/select-checkboxes.vue
+++ b/vue/components/ui/molecules/select-checkboxes/select-checkboxes.vue
@@ -177,7 +177,7 @@ export const SelectCheckboxes = {
         }
     },
     methods: {
-        scrollToCheckbox(_key, keyBuffer) {
+        scrollToCheckbox(key, keyBuffer) {
             const index = this._items.findIndex(option =>
                 option.label?.toUpperCase().startsWith(keyBuffer)
             );

--- a/vue/components/ui/molecules/select-checkboxes/select-checkboxes.vue
+++ b/vue/components/ui/molecules/select-checkboxes/select-checkboxes.vue
@@ -125,10 +125,10 @@ export const SelectCheckboxes = {
     },
     data: function() {
         return {
-            highlighted: null,
-            valuesData: this.values,
+            highlighted: null,            
             keyBuffer: "",
-            keyTimestamp: 0
+            keyTimestamp: 0,
+            valuesData: this.values
         };
     },
     computed: {

--- a/vue/components/ui/molecules/select/select.vue
+++ b/vue/components/ui/molecules/select/select.vue
@@ -153,11 +153,11 @@
 </style>
 
 <script>
-import { partMixin, utilsMixin } from "../../../../mixins";
+import { partMixin, scrollMixin } from "../../../../mixins";
 
 export const Select = {
     name: "select-ripe",
-    mixins: [partMixin, utilsMixin],
+    mixins: [partMixin, scrollMixin],
     props: {
         options: {
             type: Array,
@@ -327,7 +327,6 @@ export const Select = {
         scrollTo(index) {
             const dropdown = this.$refs.dropdown.$refs.dropdown;
             const dropdownElements = dropdown.getElementsByClassName("dropdown-item");
-
             this.scrollToIndex(dropdown, dropdownElements, index);
         },
         onGlobalClick(event) {

--- a/vue/components/ui/molecules/select/select.vue
+++ b/vue/components/ui/molecules/select/select.vue
@@ -153,11 +153,11 @@
 </style>
 
 <script>
-import { partMixin } from "../../../../mixins";
+import { partMixin, utilsMixin } from "../../../../mixins";
 
 export const Select = {
     name: "select-ripe",
-    mixins: [partMixin],
+    mixins: [partMixin, utilsMixin],
     props: {
         options: {
             type: Array,
@@ -328,23 +328,7 @@ export const Select = {
             const dropdown = this.$refs.dropdown.$refs.dropdown;
             const dropdownElements = dropdown.getElementsByClassName("dropdown-item");
 
-            const visibleStart = dropdown.scrollTop;
-            const visibleEnd = visibleStart + dropdown.clientHeight;
-
-            let indexStart = 0;
-            for (let i = 0; i < index; i++) {
-                const dropdownElement = dropdownElements[i];
-                indexStart += dropdownElement.offsetHeight;
-            }
-
-            const indexHeight = dropdownElements[index].offsetHeight;
-            const indexEnd = indexStart + indexHeight;
-
-            if (indexStart < visibleStart) {
-                dropdown.scrollTop = indexStart;
-            } else if (indexEnd > visibleEnd) {
-                dropdown.scrollTop = indexEnd - dropdown.clientHeight;
-            }
+            this.scrollToIndexDropdown(dropdown, dropdownElements, index);
         },
         onGlobalClick(event) {
             const owners = Array.isArray(this.owners)
@@ -373,6 +357,7 @@ export const Select = {
             }
             this.keyBuffer += key.toUpperCase();
             this.keyTimestamp = Date.now();
+            this.$emit("select:keydown", this.keyBuffer);
             this.highlightBestMatchOption();
         },
         onEscKey() {

--- a/vue/components/ui/molecules/select/select.vue
+++ b/vue/components/ui/molecules/select/select.vue
@@ -328,7 +328,7 @@ export const Select = {
             const dropdown = this.$refs.dropdown.$refs.dropdown;
             const dropdownElements = dropdown.getElementsByClassName("dropdown-item");
 
-            this.scrollToIndexDropdown(dropdown, dropdownElements, index);
+            this.scrollToIndex(dropdown, dropdownElements, index);
         },
         onGlobalClick(event) {
             const owners = Array.isArray(this.owners)
@@ -357,7 +357,7 @@ export const Select = {
             }
             this.keyBuffer += key.toUpperCase();
             this.keyTimestamp = Date.now();
-            this.$emit("select:keydown", this.keyBuffer);
+            this.$emit("select:keydown", key, this.keyBuffer);
             this.highlightBestMatchOption();
         },
         onEscKey() {

--- a/vue/mixins/scroll.js
+++ b/vue/mixins/scroll.js
@@ -56,6 +56,38 @@ export const scrollMixin = {
                 top: 0,
                 left: 0
             });
+        },
+        /**
+         * Scrolls into requested  element for a container,
+         * given the index of the element to scroll to.
+         *
+         * This method assumes that the elements contained in
+         * the container are all regular and equivalent.
+         *
+         * @param {HTMLElement} container The parent container element.
+         * @param {HTMLCollection} elements List of elements to iterate over.
+         * @param {Number} index The index of the target element to
+         * scroll to.
+         */
+        scrollToIndex(container, elements, index) {
+            if (index < 0) return;
+
+            const visibleStart = container.scrollTop;
+            const visibleEnd = visibleStart + container.clientHeight;
+
+            let indexStart = 0;
+            for (let i = 0; i < index; i++) {
+                indexStart += elements[i].offsetHeight;
+            }
+
+            const indexHeight = elements[index].offsetHeight;
+            const indexEnd = indexStart + indexHeight;
+
+            if (indexStart < visibleStart) {
+                container.scrollTop = indexStart;
+            } else if (indexEnd > visibleEnd) {
+                container.scrollTop = indexEnd - container.clientHeight;
+            }
         }
     }
 };

--- a/vue/mixins/utils.js
+++ b/vue/mixins/utils.js
@@ -26,32 +26,6 @@ export const utilsMixin = {
         },
         buildSlug(value) {
             return buildSlug(value);
-        },
-        /**
-         * Scrolls to the right element for a container,
-         * given the index of the element to scroll to.
-         *
-         * @param {HTMLElement} container The parent container;
-         * @param {HTMLCollection} elements List of elements to iterate over;
-         * @param {Number} index The index of the target element;
-         */
-        scrollToIndex(container, elements, index) {
-            const visibleStart = container.scrollTop;
-            const visibleEnd = visibleStart + container.clientHeight;
-
-            let indexStart = 0;
-            for (let i = 0; i < index; i++) {
-                indexStart += elements[i].offsetHeight;
-            }
-
-            const indexHeight = elements[index].offsetHeight;
-            const indexEnd = indexStart + indexHeight;
-
-            if (indexStart < visibleStart) {
-                container.scrollTop = indexStart;
-            } else if (indexEnd > visibleEnd) {
-                container.scrollTop = indexEnd - container.clientHeight;
-            }
         }
     }
 };

--- a/vue/mixins/utils.js
+++ b/vue/mixins/utils.js
@@ -27,9 +27,16 @@ export const utilsMixin = {
         buildSlug(value) {
             return buildSlug(value);
         },
-        scrollToIndexDropdown(dropdown, elements, index) {
-            const visibleStart = dropdown.scrollTop;
-            const visibleEnd = visibleStart + dropdown.clientHeight;
+        /**
+         * Scrolls to the right element for a container,
+         * given the index of the element to scroll to.
+         * @param {*} container The parent container;
+         * @param {*} elements List of elements to iterate over;
+         * @param {*} index The index of the target element;
+         */
+        scrollToIndex(container, elements, index) {
+            const visibleStart = container.scrollTop;
+            const visibleEnd = visibleStart + container.clientHeight;
 
             let indexStart = 0;
             for (let i = 0; i < index; i++) {
@@ -40,9 +47,9 @@ export const utilsMixin = {
             const indexEnd = indexStart + indexHeight;
 
             if (indexStart < visibleStart) {
-                dropdown.scrollTop = indexStart;
+                container.scrollTop = indexStart;
             } else if (indexEnd > visibleEnd) {
-                dropdown.scrollTop = indexEnd - dropdown.clientHeight;
+                container.scrollTop = indexEnd - container.clientHeight;
             }
         }
     }

--- a/vue/mixins/utils.js
+++ b/vue/mixins/utils.js
@@ -35,7 +35,6 @@ export const utilsMixin = {
          * @param {HTMLCollection} elements List of elements to iterate over;
          * @param {Number} index The index of the target element;
          */
-
         scrollToIndex(container, elements, index) {
             const visibleStart = container.scrollTop;
             const visibleEnd = visibleStart + container.clientHeight;

--- a/vue/mixins/utils.js
+++ b/vue/mixins/utils.js
@@ -30,10 +30,12 @@ export const utilsMixin = {
         /**
          * Scrolls to the right element for a container,
          * given the index of the element to scroll to.
-         * @param {*} container The parent container;
-         * @param {*} elements List of elements to iterate over;
-         * @param {*} index The index of the target element;
+         *
+         * @param {HTMLElement} container The parent container;
+         * @param {HTMLCollection} elements List of elements to iterate over;
+         * @param {Number} index The index of the target element;
          */
+
         scrollToIndex(container, elements, index) {
             const visibleStart = container.scrollTop;
             const visibleEnd = visibleStart + container.clientHeight;

--- a/vue/mixins/utils.js
+++ b/vue/mixins/utils.js
@@ -26,6 +26,24 @@ export const utilsMixin = {
         },
         buildSlug(value) {
             return buildSlug(value);
+        },
+        scrollToIndexDropdown(dropdown, elements, index) {
+            const visibleStart = dropdown.scrollTop;
+            const visibleEnd = visibleStart + dropdown.clientHeight;
+
+            let indexStart = 0;
+            for (let i = 0; i < index; i++) {
+                indexStart += elements[i].offsetHeight;
+            }
+
+            const indexHeight = elements[index].offsetHeight;
+            const indexEnd = indexStart + indexHeight;
+
+            if (indexStart < visibleStart) {
+                dropdown.scrollTop = indexStart;
+            } else if (indexEnd > visibleEnd) {
+                dropdown.scrollTop = indexEnd - dropdown.clientHeight;
+            }
         }
     }
 };


### PR DESCRIPTION
| -| - | 
| ---| --- | 
| Issue | https://github.com/ripe-tech/ripe-util-vue/issues/125 |
| Dependencies | None |
| Decisions | Select checkboxes didn't have the feature to scroll to the closest match when input is given, so this PR adds that feature.  |
| Animated GIF | ![Peek 2021-07-22 09-31](https://user-images.githubusercontent.com/22790704/126611062-11ea88f1-35d1-49ef-a631-8aa84f715cce.gif) |


