### PR TITLE
#60 Visual Testing  -  image list more evident selected image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Added home navigation button `error-part`
-* Selected images can now be more evident on `image-list`, by lowering the opacity of the unselected ones.
+* Selected images can now be more evident on `image-list`, by lowering the opacity of the unselected ones
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Added home navigation button `error-part`
+* Selected images can now be more evident on `image-list`, by lowering the opacity of the unselected ones.
 
 ### Changed
 

--- a/vue/components/ui/molecules/image-list/image-list.vue
+++ b/vue/components/ui/molecules/image-list/image-list.vue
@@ -1,6 +1,7 @@
 <template>
     <div class="image-list">
         <image-item
+            v-bind:style="style(index)"
             v-bind:image-url="item.imageUrl"
             v-bind:name="item.name"
             v-bind:description="item.description"
@@ -105,7 +106,19 @@ export const ImageList = {
         animationDuration: {
             type: Number,
             default: 2000
+        },
+        /**
+         * The value the opacity for the unselected images.
+         */
+        opacityUnselected: {
+            type: Number,
+            default: 1
         }
+    },
+    data: function() {
+        return {
+            selectedItemIndex: 0
+        };
     },
     computed: {
         listeners() {
@@ -131,10 +144,18 @@ export const ImageList = {
             this.$emit("update:highlight", item, index, value);
         },
         onClick(event, item, index) {
+            this.selectedItemIndex = index;
             this.$emit("click", event, item, index);
         },
         onButtonClick(event, item, index) {
+            this.selectedItemIndex = index;
             this.$emit("click:button", event, item, index);
+        },
+        style(index) {
+            const base = {
+                opacity: index === this.selectedItemIndex ? "1" : this.opacityUnselected
+            };
+            return base;
         }
     }
 };

--- a/vue/components/ui/molecules/image-list/image-list.vue
+++ b/vue/components/ui/molecules/image-list/image-list.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="image-list">
         <image-item
-            v-bind:style="style(index)"
+            v-bind:style="itemStyle(index)"
             v-bind:image-url="item.imageUrl"
             v-bind:name="item.name"
             v-bind:description="item.description"
@@ -9,7 +9,7 @@
             v-bind:highlight-color="highlightColor"
             v-bind:image-object-fit="item.objectFit"
             v-bind:animation-duration="animationDuration"
-            v-bind="options(item)"
+            v-bind="itemOptions(item)"
             v-for="(item, index) in items"
             v-bind:key="item.id || index"
             v-on:click="event => onClick(event, item, index)"
@@ -108,7 +108,8 @@ export const ImageList = {
             default: 2000
         },
         /**
-         * The value the opacity for the unselected images.
+         * The values for the opacity CSS value to be used in
+         * images that are currently not selected.
          */
         opacityUnselected: {
             type: Number,
@@ -117,7 +118,7 @@ export const ImageList = {
     },
     data: function() {
         return {
-            selectedItemIndex: 0
+            selectedIndex: 0
         };
     },
     computed: {
@@ -130,7 +131,7 @@ export const ImageList = {
         }
     },
     methods: {
-        options(item) {
+        itemOptions(item) {
             const base = {
                 height: this.itemHeight,
                 width: this.itemWidth,
@@ -140,22 +141,22 @@ export const ImageList = {
             };
             return base;
         },
+        itemStyle(index) {
+            const base = {
+                opacity: index === this.selectedIndex ? "1" : this.opacityUnselected
+            };
+            return base;
+        },
         onUpdateHighlight(item, index, value) {
             this.$emit("update:highlight", item, index, value);
         },
         onClick(event, item, index) {
-            this.selectedItemIndex = index;
+            this.selectedIndex = index;
             this.$emit("click", event, item, index);
         },
         onButtonClick(event, item, index) {
-            this.selectedItemIndex = index;
+            this.selectedIndex = index;
             this.$emit("click:button", event, item, index);
-        },
-        style(index) {
-            const base = {
-                opacity: index === this.selectedItemIndex ? "1" : this.opacityUnselected
-            };
-            return base;
         }
     }
 };


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Making the selected images more evident, as mentioned in https://github.com/ripe-tech/ripe-util-vue/issues/60#issuecomment-874229687 |
| Decisions | Allowed the opacity of the unselected images to be lowered by props. |
| Animated GIF | ![](http://g.recordit.co/B3ew9Aih7B.gif) |
