### PR TITLE
Upload Area: area container visibility prop

### DIFF
--- a/vue/components/ui/molecules/upload-area/upload-area.stories.js
+++ b/vue/components/ui/molecules/upload-area/upload-area.stories.js
@@ -14,6 +14,9 @@ storiesOf("Components/Molecules/Upload Area", module)
             disabled: {
                 default: boolean("Disabled", true)
             },
+            areaContainer: {
+                default: boolean("Upload Area", true)
+            },
             draggingIcon: {
                 default: select(
                     "Icon",
@@ -42,6 +45,7 @@ storiesOf("Components/Molecules/Upload Area", module)
                 <upload-area 
                     v-bind:files.sync="filesData" 
                     v-bind:description="description"
+                    v-bind:area-container="areaContainer"
                     v-bind:description-dragging="descriptionDragging"
                     v-bind:dragging-icon="draggingIcon"
                     v-bind:disabled="disabled"

--- a/vue/components/ui/molecules/upload-area/upload-area.vue
+++ b/vue/components/ui/molecules/upload-area/upload-area.vue
@@ -22,10 +22,10 @@
                         {{ descriptionText }}
                     </div>
                 </transition>
-                <button-icon v-bind:icon="icon" v-bind:size="110" />
+                <button-icon v-bind:icon="icon" v-bind:size="110" v-if="areaContainer" />
                 <button-color
                     class="button-upload"
-                    v-bind:text="'Upload File'"
+                    v-bind:text="buttonText"
                     v-bind:icon="'cloud-upload'"
                     v-bind:alignment="'center'"
                     v-bind:disabled="disabled"
@@ -39,6 +39,10 @@
 <style lang="scss" scoped>
 @import "css/variables.scss";
 @import "css/animations.scss";
+
+.upload-area.hidden-area-container {
+    display: inline-block;
+}
 
 .upload-area > .upload-area-container {
     align-items: center;
@@ -64,12 +68,21 @@
     cursor: not-allowed;
 }
 
+.upload-area.hidden-area-container > .upload-area-container {
+    border: none;
+    height: initial;
+}
+
 .upload-area > .upload-area-container > .description {
     color: $dark;
     font-size: 14px;
     font-weight: 600;
     letter-spacing: 0.5px;
     margin-bottom: 22px;
+}
+
+.upload-area.hidden-area-container .upload-area-container > .description {
+    display: none;
 }
 
 .upload-area > .upload-area-container > .description.fade-in-enter-active,
@@ -104,6 +117,10 @@
 .upload-area.dragging > .upload-area-container > .button-upload {
     opacity: 0;
 }
+
+.upload-area.dragging.hidden-area-container > .upload-area-container > .button-upload {
+    opacity: 0.6;
+}
 </style>
 
 <script>
@@ -117,6 +134,14 @@ export const UploadArea = {
         descriptionDragging: {
             type: String,
             default: "Drop your files to upload"
+        },
+        buttonText: {
+            type: String,
+            default: "Upload Files"
+        },
+        areaContainer: {
+            type: Boolean,
+            default: true
         },
         disabled: {
             type: Boolean,
@@ -147,7 +172,11 @@ export const UploadArea = {
             return this.draggingIcon ? this.draggingIcon : "cloud-upload";
         },
         classes() {
-            const base = { dragging: this.dragging, disabled: this.draggingDisabled };
+            const base = {
+                dragging: this.dragging,
+                disabled: this.draggingDisabled,
+                "hidden-area-container": !this.areaContainer
+            };
             return base;
         }
     },


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-util-vue/issues/199 |
| Decisions | - Add `buttonText` to control the upload button text. <br> - Add `areContainer` prop to toggle the visibility of the upload-area-container extra area or hide it and just show the button.  |

https://user-images.githubusercontent.com/24736423/132326013-9a04e889-ffbd-46be-af7d-1e8828e84ca3.mov
