### PR TITLE
Listing: add key only option to addFilter

### DIFF
--- a/vue/components/ui/organisms/listing/listing.vue
+++ b/vue/components/ui/organisms/listing/listing.vue
@@ -401,9 +401,9 @@ export const Listing = {
         }
     },
     methods: {
-        addFilter(key, value) {
-            const base = value ? `${key}=` : `${key}`;
-            const tuple = value ? `${key}=${value}` : `${key}`;
+        addFilter(key, value = undefined) {
+            const base = value === undefined ? `${key}` : `${key}=`;
+            const tuple = value === undefined ? `${key}` : `${key}=${value}`;
             if (this.filter && this.filter.search(base) !== -1) return;
             this.filter += this.filter ? ` and ${tuple}` : tuple;
             this.showScrollTop = true;

--- a/vue/components/ui/organisms/listing/listing.vue
+++ b/vue/components/ui/organisms/listing/listing.vue
@@ -402,8 +402,8 @@ export const Listing = {
     },
     methods: {
         addFilter(key, value) {
-            const base = `${key}=`;
-            const tuple = `${key}=${value}`;
+            const base = value ? `${key}=` : `${key}`;
+            const tuple = value ? `${key}=${value}` : `${key}`;
             if (this.filter && this.filter.search(base) !== -1) return;
             this.filter += this.filter ? ` and ${tuple}` : tuple;
             this.showScrollTop = true;


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-pulse/issues/234 |
| Decisions | - Add key only option to allow adding filters like addFilter("@today") resulting in `@today` instead of `@today=undefined` |
