### PR TITLE
Button Upload: label and multiple fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Adapt upload-area structure to use button-upload
 * Adapt chat and input-image to upload-area new structure
+* Display non plural text when multiple is false in button-upload
 
 ### Fixed
 
-*
+* Only setting the first file when multiple files dragged with prop `multiple: false` in button-upload
 
 ## [0.15.0] - 2021-08-30
 

--- a/vue/components/ui/molecules/button-upload/button-upload.stories.js
+++ b/vue/components/ui/molecules/button-upload/button-upload.stories.js
@@ -8,6 +8,9 @@ storiesOf("Components/Molecules/Button Upload", module)
             disabled: {
                 default: boolean("Disabled", false)
             },
+            multiple: {
+                default: boolean("Multiple", true)
+            },
             buttonText: {
                 default: text("Button Text", "Upload Files")
             }
@@ -22,6 +25,7 @@ storiesOf("Components/Molecules/Button Upload", module)
             <div>
                 <button-upload 
                     v-bind:files.sync="filesData" 
+                    v-bind:multiple="multiple" 
                     v-bind:button-text="buttonText"
                     v-bind:disabled="disabled"
                 />

--- a/vue/components/ui/molecules/button-upload/button-upload.vue
+++ b/vue/components/ui/molecules/button-upload/button-upload.vue
@@ -18,7 +18,7 @@
         <slot v-bind:open-modal="openModal" />
         <button-color
             class="button-upload"
-            v-bind:text="buttonText"
+            v-bind:text="buttonText || buttonTextComputed"
             v-bind:icon="'cloud-upload'"
             v-bind:alignment="'center'"
             v-bind:disabled="disabled"
@@ -57,7 +57,7 @@ export const ButtonUpload = {
     props: {
         buttonText: {
             type: String,
-            default: "Upload Files"
+            default: null
         },
         disabled: {
             type: Boolean,
@@ -82,6 +82,10 @@ export const ButtonUpload = {
                 disabled: this.draggingDisabled
             };
             return base;
+        },
+        buttonTextComputed() {
+            if (this.multiple) return "Upload Files";
+            return "Upload File";
         }
     },
     watch: {

--- a/vue/components/ui/molecules/button-upload/button-upload.vue
+++ b/vue/components/ui/molecules/button-upload/button-upload.vue
@@ -63,10 +63,6 @@ export const ButtonUpload = {
             type: Boolean,
             default: false
         },
-        multiple: {
-            type: Boolean,
-            default: true
-        },
         accept: {
             type: String,
             default: null

--- a/vue/mixins/upload.js
+++ b/vue/mixins/upload.js
@@ -30,11 +30,7 @@ export const uploadMixin = {
             this.fileInputRef = filesInputRef;
         },
         setFiles(filesList) {
-            if (!this.multiple) {
-                this.filesData = [filesList[0]];
-            } else {
-                this.filesData = [...filesList];
-            }
+            this.filesData = this.multiple ? [...filesList] : [filesList[0]];
             this.$emit("update:files", this.filesData);
         },
         clear() {

--- a/vue/mixins/upload.js
+++ b/vue/mixins/upload.js
@@ -11,6 +11,10 @@ export const uploadMixin = {
         draggable: {
             type: Boolean,
             default: true
+        },
+        multiple: {
+            type: Boolean,
+            default: true
         }
     },
     data: function() {
@@ -26,7 +30,11 @@ export const uploadMixin = {
             this.fileInputRef = filesInputRef;
         },
         setFiles(filesList) {
-            this.filesData = [...filesList];
+            if (!this.multiple) {
+                this.filesData = [filesList[0]];
+            } else {
+                this.filesData = [...filesList];
+            }
             this.$emit("update:files", this.filesData);
         },
         clear() {


### PR DESCRIPTION

| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-components-vue/pull/532#issuecomment-916710005 |
| Decisions | - Fix `buttonText` label when multiple is `true` <br> - Fix multiple files being set when dragging even when multiple was set to `false` |
| Animated GIF | ![Peek 2021-09-10 11-18](https://user-images.githubusercontent.com/24736423/132839170-57b698b9-e8dd-42bb-9d87-184cbededcd6.gif) |
