### PR TITLE
#240 Auto load more and forceItemsLoad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * New `button-upload` component
 * Search clear prop on `listing`
 * Scrolling sync events like `isScrollAtBottom` on `listing`
+* Add `forceItemsLoad` to listing and filter
+* Add auto load after update items to listing
 
 ### Changed
 

--- a/vue/components/ui/molecules/filter/filter.vue
+++ b/vue/components/ui/molecules/filter/filter.vue
@@ -169,6 +169,10 @@ export const Filter = {
             type: Number,
             default: 200
         },
+        forceItemsToLoad: {
+            type: Boolean,
+            default: false
+        },
         useQuery: {
             type: Boolean,
             default: false
@@ -341,7 +345,7 @@ export const Filter = {
             this.tableTransition = pagination || this.items.length === 0 ? "fade" : "";
             this.items = !pagination ? items : [...this.items, ...items];
             this.loading = false;
-            this.itemsToLoad = items.length === this.limit;
+            this.itemsToLoad = this.forceItemsToLoad || items.length === this.limit;
 
             // returns a valid value as an "effective" refresh operation
             // has just been performed (all tests passed)

--- a/vue/components/ui/molecules/filter/filter.vue
+++ b/vue/components/ui/molecules/filter/filter.vue
@@ -169,7 +169,7 @@ export const Filter = {
             type: Number,
             default: 200
         },
-        forceItemsToLoad: {
+        forceItemsLoad: {
             type: Boolean,
             default: false
         },
@@ -345,7 +345,7 @@ export const Filter = {
             this.tableTransition = pagination || this.items.length === 0 ? "fade" : "";
             this.items = !pagination ? items : [...this.items, ...items];
             this.loading = false;
-            this.itemsToLoad = this.forceItemsToLoad || items.length === this.limit;
+            this.itemsToLoad = this.forceItemsLoad || items.length === this.limit;
 
             // returns a valid value as an "effective" refresh operation
             // has just been performed (all tests passed)

--- a/vue/components/ui/organisms/listing/listing.vue
+++ b/vue/components/ui/organisms/listing/listing.vue
@@ -111,7 +111,7 @@
                 v-bind:options.sync="filterOptions"
                 v-bind:checkboxes="checkboxes"
                 v-bind:checked-items.sync="checkedItemsData"
-                v-bind:force-items-to-load="forceItemsToLoad"
+                v-bind:force-items-load="forceItemsLoad"
                 ref="filter"
                 v-on:update:options="filterUpdated"
                 v-on:update:items="onUpdateItems"
@@ -388,7 +388,7 @@ export const Listing = {
             type: String | Object,
             default: null
         },
-        forceItemsToLoad: {
+        forceItemsLoad: {
             type: Boolean,
             default: false
         }

--- a/vue/components/ui/organisms/listing/listing.vue
+++ b/vue/components/ui/organisms/listing/listing.vue
@@ -111,8 +111,10 @@
                 v-bind:options.sync="filterOptions"
                 v-bind:checkboxes="checkboxes"
                 v-bind:checked-items.sync="checkedItemsData"
+                v-bind:force-items-to-load="forceItemsToLoad"
                 ref="filter"
                 v-on:update:options="filterUpdated"
+                v-on:update:items="onUpdateItems"
                 v-on:click:table="onTableClick"
                 v-on:click:lineup="onLineupClick"
             >
@@ -385,6 +387,10 @@ export const Listing = {
         createUrl: {
             type: String | Object,
             default: null
+        },
+        forceItemsToLoad: {
+            type: Boolean,
+            default: false
         }
     },
     data: function() {

--- a/vue/components/ui/organisms/listing/listing.vue
+++ b/vue/components/ui/organisms/listing/listing.vue
@@ -434,6 +434,9 @@ export const Listing = {
         },
         onLineupClick(item, index) {
             this.$emit("click:lineup", item, index);
+        },
+        onUpdateItems() {
+            if (this.shouldLoadMore) this?.getFilter()?.loadMore();
         }
     },
     computed: {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-pulse/issues/240 |
| Dependencies | https://github.com/ripe-tech/ripe-components-vue/pull/536 |
| Decisions | - Add `forceItemsLoad` to listing and filter <br> - Add auto load after update items to listing |

