### PR TITLE
Listing: auto load more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * New `button-upload` component
 * Search clear prop on `listing`
+* Auto load more after each update of items in `listing`
 
 ### Changed
 

--- a/vue/components/ui/organisms/listing/listing.vue
+++ b/vue/components/ui/organisms/listing/listing.vue
@@ -113,6 +113,7 @@
                 v-bind:checked-items.sync="checkedItemsData"
                 ref="filter"
                 v-on:update:options="filterUpdated"
+                v-on:update:items="onUpdateItems"
                 v-on:click:table="onTableClick"
                 v-on:click:lineup="onLineupClick"
             >
@@ -434,6 +435,9 @@ export const Listing = {
         },
         onLineupClick(item, index) {
             this.$emit("click:lineup", item, index);
+        },
+        onUpdateItems() {
+            if (this.shouldLoadMore) this?.getFilter()?.loadMore();
         }
     },
     computed: {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Dependencies | https://github.com/ripe-tech/ripe-components-vue/pull/536 |
| Decisions | - Add auto load more after update items in `listing` |
| Animated GIF | Below |

### Load more for a listing component with prop `limit:  1`

https://user-images.githubusercontent.com/24736423/134891121-bf571431-17c7-4e91-97fe-452d2496f7f9.gif