### PR TITLE
feat: image item list selected style

### DIFF
--- a/vue/components/ui/atoms/image-item/image-item.vue
+++ b/vue/components/ui/atoms/image-item/image-item.vue
@@ -38,7 +38,7 @@
         </div>
         <div
             class="item-image"
-            v-bind:style="imageStyle"
+            v-bind:style="itemImageStyle"
             v-bind:class="{ 'dropdown-open': optionsVisible }"
             ref="image"
             v-on:animationend="onAnimationEnd"
@@ -216,6 +216,20 @@ export const ImageItem = {
             default: "#aeffe2"
         },
         /**
+         * If the item displays the selected border.
+         */
+        selected: {
+            type: Boolean,
+            default: false
+        },
+        /**
+         * The border color of the selected style.
+         */
+        selectedColor: {
+            type: String,
+            default: "#4078c0"
+        },
+        /**
          * The duration of the highlight animation.
          */
         animationDuration: {
@@ -235,6 +249,14 @@ export const ImageItem = {
         },
         optionsScopedSlots() {
             return Object.keys(this.$scopedSlots).filter(slot => slot.startsWith("options-"));
+        },
+        itemImageStyle() {
+            const base = {};
+            if (this.height) base.height = `${this.height}px`;
+            if (this.width) base.width = `${this.width}px`;
+            if (this.imageObjectFit) base.objectFit = this.imageObjectFit;
+            if (this.selected) base.border = `1px solid ${this.selectedColor}`;
+            return base;
         },
         imageStyle() {
             const base = {};

--- a/vue/components/ui/molecules/image-list/image-list.vue
+++ b/vue/components/ui/molecules/image-list/image-list.vue
@@ -6,7 +6,9 @@
             v-bind:name="item.name"
             v-bind:description="item.description"
             v-bind:highlight="highlightIndex === index"
+            v-bind:selected="selectedIndexData === index"
             v-bind:highlight-color="highlightColor"
+            v-bind:selected-color="selectedColor"
             v-bind:image-object-fit="item.objectFit"
             v-bind:animation-duration="animationDuration"
             v-bind="itemOptions(item)"
@@ -101,6 +103,21 @@ export const ImageList = {
             default: "#aeffe2"
         },
         /**
+         * The index of the image that is selected (will show
+         * a border around it).
+         */
+        selectedIndex: {
+            type: Number,
+            default: null
+        },
+        /**
+         * The border color of the select style.
+         */
+        selectedColor: {
+            type: String,
+            default: "#4078c0"
+        },
+        /**
          * The duration of the highlight animation.
          */
         animationDuration: {
@@ -118,7 +135,7 @@ export const ImageList = {
     },
     data: function() {
         return {
-            selectedIndex: 0
+            selectedIndexData: 0
         };
     },
     computed: {
@@ -128,6 +145,14 @@ export const ImageList = {
             delete listeners["click:button"];
             delete listeners["update:highlight"];
             return listeners;
+        }
+    },
+    watch: {
+        selectedIndex(value) {
+            this.selectedIndexData = value;
+        },
+        selectedIndexData(value) {
+            this.$emit("update:selected-index", value);
         }
     },
     methods: {
@@ -143,7 +168,7 @@ export const ImageList = {
         },
         itemStyle(index) {
             const base = {
-                opacity: index === this.selectedIndex ? "1" : this.opacityUnselected
+                opacity: index === this.selectedIndexData ? "1" : this.opacityUnselected
             };
             return base;
         },
@@ -151,11 +176,11 @@ export const ImageList = {
             this.$emit("update:highlight", item, index, value);
         },
         onClick(event, item, index) {
-            this.selectedIndex = index;
+            this.selectedIndexData = index;
             this.$emit("click", event, item, index);
         },
         onButtonClick(event, item, index) {
-            this.selectedIndex = index;
+            this.selectedIndexData = index;
             this.$emit("click:button", event, item, index);
         }
     }


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Related to https://github.com/ripe-tech/ripe-util-vue/issues/214#issuecomment-954504759 |
| Dependencies | -- |
| Decisions | - Support for selected style (show border in selected item in the list)<br>- Fix overflow cut in the left side of the image list (GIF below)<br>![image-ist-left-overflow](https://user-images.githubusercontent.com/25725586/139424262-741883e3-a03c-4035-b200-efc8ab8aff8b.gif)|
| Animated GIF | Selected style:<br>![order-validation-image-list-selected](https://user-images.githubusercontent.com/25725586/139424295-e96f812d-a556-49c9-8a16-92138f5613fe.gif)<br>Fix overflow cut:<br>![image-ist-left-overflow-fix](https://user-images.githubusercontent.com/25725586/139424331-87c12d8c-0083-47d5-bd23-2d6545a9e6ed.gif)|
