### PR TITLE
Listing: clickable rows

### DIFF
--- a/vue/components/ui/molecules/filter/filter.vue
+++ b/vue/components/ui/molecules/filter/filter.vue
@@ -10,6 +10,7 @@
                 v-bind:reverse="reverse"
                 v-bind:alignment="tableAlignment"
                 v-bind:variant="tableVariant"
+                v-bind:clickable-rows="clickableRows"
                 v-bind:checkboxes="checkboxes"
                 v-bind:checked-items="checkedItems"
                 v-on:update:checked-items="value => $emit('update:checked-items', value)"
@@ -140,6 +141,10 @@ export const Filter = {
         tableVariant: {
             type: String,
             default: null
+        },
+        clickableRows: {
+            type: Boolean,
+            default: true
         },
         lineupFields: {
             type: Array,

--- a/vue/components/ui/organisms/listing/listing.vue
+++ b/vue/components/ui/organisms/listing/listing.vue
@@ -160,6 +160,10 @@
     color: $link-hover-color;
 }
 
+::v-deep .clickable {
+    cursor: pointer;
+}
+
 .scroll-button {
     background: $white url("~./assets/arrow-up.svg") no-repeat center;
     border: none;

--- a/vue/components/ui/organisms/listing/listing.vue
+++ b/vue/components/ui/organisms/listing/listing.vue
@@ -160,10 +160,6 @@
     color: $link-hover-color;
 }
 
-::v-deep .clickable {
-    cursor: pointer;
-}
-
 .scroll-button {
     background: $white url("~./assets/arrow-up.svg") no-repeat center;
     border: none;

--- a/vue/components/ui/organisms/listing/listing.vue
+++ b/vue/components/ui/organisms/listing/listing.vue
@@ -101,6 +101,7 @@
                 v-bind:lineup-fields="lineupFields"
                 v-bind:lineup-columns="lineupColumns"
                 v-bind:lineup-variant="lineupVariant"
+                v-bind:clickable-rows="clickableRows"
                 v-bind:limit="limit"
                 v-bind:default-reverse="defaultReverse"
                 v-bind:default-sort="defaultSort"
@@ -310,6 +311,10 @@ export const Listing = {
         lineupVariant: {
             type: String,
             default: null
+        },
+        clickableRows: {
+            type: Boolean,
+            default: true
         },
         limit: {
             type: Number,


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Currently the rows of the `<listing>` component are styled with `cursor: pointer` but actually not all that area is clickable in most cases.  |
| Decisions | - Add missing `clickableRows` prop so we're able to control table's prop from filter or listing component. <br> - Add missing `::v-deep .clickable` selector styling for specific items we want as clickable in listing |
| Animated GIF | Below |

### Before
![Peek 2021-11-03 12-43](https://user-images.githubusercontent.com/24736423/140062116-15857dd1-fbce-451c-b4a7-641ebac1c201.gif)

### After
![Peek 2021-11-03 12-42](https://user-images.githubusercontent.com/24736423/140062118-67a93f1b-1310-40fb-9136-05651cbfd476.gif)
