### PR TITLE
#921 SVG viewer and `svg-viewer` in `form`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* Created `svg-viewer` component - [#921](https://github.com/ripe-tech/ripe-white/issues/921)
+* Support for SVG url field in `form-ripe` component, given that the field meta is `svg-url` - [#921](https://github.com/ripe-tech/ripe-white/issues/921)
 
 ### Changed
 

--- a/vue/components/ui/atoms/index.js
+++ b/vue/components/ui/atoms/index.js
@@ -25,6 +25,7 @@ import { Reaction } from "./reaction/reaction.vue";
 import { RichTextarea } from "./rich-textarea/rich-textarea.vue";
 import { Side } from "./side/side.vue";
 import { Switcher } from "./switcher/switcher.vue";
+import { SVGViewer } from "./svg-viewer/svg-viewer.vue";
 import { Tag } from "./tag/tag.vue";
 import { Textarea } from "./textarea/textarea.vue";
 import { Title } from "./title/title.vue";
@@ -57,6 +58,7 @@ const install = Vue => {
     Vue.component("rich-textarea", RichTextarea);
     Vue.component("side", Side);
     Vue.component("switcher", Switcher);
+    Vue.component("svg-viewer", SVGViewer);
     Vue.component("tag", Tag);
     Vue.component("textarea-ripe", Textarea);
     Vue.component("title-ripe", Title);
@@ -90,6 +92,7 @@ export {
     RichTextarea,
     Side,
     Switcher,
+    SVGViewer,
     Tag,
     Textarea,
     Title

--- a/vue/components/ui/atoms/index.js
+++ b/vue/components/ui/atoms/index.js
@@ -24,8 +24,8 @@ import { Radio } from "./radio/radio.vue";
 import { Reaction } from "./reaction/reaction.vue";
 import { RichTextarea } from "./rich-textarea/rich-textarea.vue";
 import { Side } from "./side/side.vue";
-import { Switcher } from "./switcher/switcher.vue";
 import { SVGViewer } from "./svg-viewer/svg-viewer.vue";
+import { Switcher } from "./switcher/switcher.vue";
 import { Tag } from "./tag/tag.vue";
 import { Textarea } from "./textarea/textarea.vue";
 import { Title } from "./title/title.vue";
@@ -57,8 +57,8 @@ const install = Vue => {
     Vue.component("reaction", Reaction);
     Vue.component("rich-textarea", RichTextarea);
     Vue.component("side", Side);
-    Vue.component("switcher", Switcher);
     Vue.component("svg-viewer", SVGViewer);
+    Vue.component("switcher", Switcher);
     Vue.component("tag", Tag);
     Vue.component("textarea-ripe", Textarea);
     Vue.component("title-ripe", Title);
@@ -91,8 +91,8 @@ export {
     Reaction,
     RichTextarea,
     Side,
-    Switcher,
     SVGViewer,
+    Switcher,
     Tag,
     Textarea,
     Title

--- a/vue/components/ui/atoms/svg-viewer/svg-viewer.js
+++ b/vue/components/ui/atoms/svg-viewer/svg-viewer.js
@@ -1,0 +1,17 @@
+import { storiesOf } from "@storybook/vue";
+import { withKnobs, text } from "@storybook/addon-knobs";
+
+storiesOf("Components/Atoms/SVG Viewer", module)
+    .addDecorator(withKnobs)
+    .add("SVG Viewer", () => ({
+        props: {
+            url: {
+                default: text("Url", "")
+            }
+        },
+        template: `
+            <svg-viewer
+                v-bind:url="url"
+            />
+        `
+    }));

--- a/vue/components/ui/atoms/svg-viewer/svg-viewer.stories.js
+++ b/vue/components/ui/atoms/svg-viewer/svg-viewer.stories.js
@@ -5,13 +5,13 @@ storiesOf("Components/Atoms/SVG Viewer", module)
     .addDecorator(withKnobs)
     .add("SVG Viewer", () => ({
         props: {
-            url: {
-                default: text("Url", "")
+            src: {
+                default: text("Src", "")
             }
         },
         template: `
             <svg-viewer
-                v-bind:url="url"
+                v-bind:src="src"
             />
         `
     }));

--- a/vue/components/ui/atoms/svg-viewer/svg-viewer.stories.js
+++ b/vue/components/ui/atoms/svg-viewer/svg-viewer.stories.js
@@ -6,7 +6,10 @@ storiesOf("Components/Atoms/SVG Viewer", module)
     .add("SVG Viewer", () => ({
         props: {
             src: {
-                default: text("Src", "")
+                default: text(
+                    "Source",
+                    "https://cdn.platforme.com/ripe/ripe_pulse/prod/illustration.svg"
+                )
             }
         },
         template: `

--- a/vue/components/ui/atoms/svg-viewer/svg-viewer.vue
+++ b/vue/components/ui/atoms/svg-viewer/svg-viewer.vue
@@ -1,5 +1,5 @@
 <template>
-    <object class="svg-viewer" type="image/svg+xml" v-bind:data="svgData" v-if="src" />
+    <object class="svg-viewer" type="image/svg+xml" v-bind:data="svgData" />
 </template>
 
 <style scoped></style>

--- a/vue/components/ui/atoms/svg-viewer/svg-viewer.vue
+++ b/vue/components/ui/atoms/svg-viewer/svg-viewer.vue
@@ -1,5 +1,5 @@
 <template>
-    <object class="svg-viewer" type="image/svg+xml" v-bind:data="svgData" />
+    <object class="svg-viewer" type="image/svg+xml" v-bind:data="svgData" v-if="svgData" />
 </template>
 
 <style scoped></style>
@@ -18,9 +18,13 @@ export const SVGViewer = {
             svgData: null
         };
     },
+
     watch: {
-        async src(value) {
-            await this.loadSVGData(value);
+        src: {
+            handler: async function(value) {
+                await this.loadSVGData(value);
+            },
+            immediate: true
         }
     },
     created: async function() {
@@ -28,7 +32,11 @@ export const SVGViewer = {
     },
     methods: {
         async loadSVGData(src) {
-            if (!src) return;
+            if (!src) {
+                this.svgData = null;
+                return;
+            }
+
             const response = await fetch(src);
             const data = await response.text();
             const encoded = window.btoa(data);

--- a/vue/components/ui/atoms/svg-viewer/svg-viewer.vue
+++ b/vue/components/ui/atoms/svg-viewer/svg-viewer.vue
@@ -1,0 +1,41 @@
+<template>
+    <object class="svg-viewer" type="image/svg+xml" v-bind:data="svgData" v-if="src" />
+</template>
+
+<style scoped></style>
+
+<script>
+export const SVGViewer = {
+    name: "svg-viewer",
+    props: {
+        src: {
+            type: String,
+            default: null
+        }
+    },
+    data: function() {
+        return {
+            svgData: null
+        };
+    },
+    watch: {
+        async src(value) {
+            await this.loadSVGData(value);
+        }
+    },
+    created: async function() {
+        await this.loadSVGData(this.src);
+    },
+    methods: {
+        async loadSVGData(src) {
+            if (!src) return;
+            const response = await fetch(src);
+            const data = await response.text();
+            const encoded = window.btoa(data);
+            this.svgData = `data:image/svg+xml;base64,${encoded}`;
+        }
+    }
+};
+
+export default SVGViewer;
+</script>

--- a/vue/components/ui/atoms/svg-viewer/svg-viewer.vue
+++ b/vue/components/ui/atoms/svg-viewer/svg-viewer.vue
@@ -27,9 +27,6 @@ export const SVGViewer = {
             immediate: true
         }
     },
-    created: async function() {
-        await this.loadSVGData(this.src);
-    },
     methods: {
         async loadSVGData(src) {
             if (!src) {

--- a/vue/components/ui/organisms/form/form.vue
+++ b/vue/components/ui/organisms/form/form.vue
@@ -48,6 +48,23 @@
                                             v-if="fromValue(field) || field.imageSrc"
                                         />
                                     </template>
+                                    <template
+                                        v-else-if="
+                                            field.type === 'text' && field.meta === 'svg-url'
+                                        "
+                                    >
+                                        <input-ripe
+                                            v-bind:type="inputType(field)"
+                                            v-bind="field.props"
+                                            v-bind:value="fromValue(field)"
+                                            v-on:update:value="value => onValue(field, value)"
+                                        />
+                                        <svg-viewer
+                                            class="text-image"
+                                            v-bind:src="fromValue(field) || field.imageSrc"
+                                            v-if="fromValue(field) || field.imageSrc"
+                                        />
+                                    </template>
                                     <textarea-ripe
                                         v-bind="field.props"
                                         v-bind:value="fromValue(field)"

--- a/vue/components/ui/organisms/form/form.vue
+++ b/vue/components/ui/organisms/form/form.vue
@@ -61,8 +61,8 @@
                                         />
                                         <svg-viewer
                                             class="text-image"
-                                            v-bind:src="fromValue(field) || field.imageSrc"
-                                            v-show="fromValue(field) || field.imageSrc"
+                                            v-bind:src="fromValue(field) || field.svgSrc"
+                                            v-show="fromValue(field) || field.svgSrc"
                                         />
                                     </template>
                                     <textarea-ripe

--- a/vue/components/ui/organisms/form/form.vue
+++ b/vue/components/ui/organisms/form/form.vue
@@ -62,7 +62,7 @@
                                         <svg-viewer
                                             class="text-image"
                                             v-bind:src="fromValue(field) || field.imageSrc"
-                                            v-if="fromValue(field) || field.imageSrc"
+                                            v-show="fromValue(field) || field.imageSrc"
                                         />
                                     </template>
                                     <textarea-ripe


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-white/issues/921 |
| Dependencies | -- |
| Decisions | • Create `svg-viewer` component which let's us preview an SVG or SVGA given the file URL<br>• Support for SVG url field for `form-ripe` component, given that the field meta is `svg-url` |

https://user-images.githubusercontent.com/22588915/140169854-106c11bd-c523-4856-a05d-cfbc54379939.mp4

