### PR TITLE
fix: filter setItem $set usage

### DIFF
--- a/vue/components/ui/molecules/filter/filter.vue
+++ b/vue/components/ui/molecules/filter/filter.vue
@@ -297,7 +297,7 @@ export const Filter = {
             this.$router.replace({ query: next });
         },
         setItem(index, item) {
-            this.items.$set(index, item);
+            this.$set(this.items, index, item);
         },
         removeItem(index) {
             this.items.splice(index, 1);


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Using this in https://github.com/ripe-tech/ripe-util-vue/pull/229, where its necessary to update a table item after some update on it. The `$set` was being used incorrectly. |
| Dependencies | -- |
| Decisions | - The `$set` was being used incorrectly, fixed that. |
| Animated GIF | -- |
