### PR TITLE
#296 Add `textColor` prop to `tag` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Added variant "white" to `input-image`
+* Added prop `textColor` to `tag` component to allow customizing the text color - [#296](https://github.com/ripe-tech/ripe-pulse/issues/296)
 
 ### Changed
 

--- a/vue/components/ui/atoms/tag/tag.vue
+++ b/vue/components/ui/atoms/tag/tag.vue
@@ -142,6 +142,10 @@ export const Tag = {
         subtle: {
             type: Boolean,
             default: true
+        },
+        textColor: {
+            type: String,
+            default: null
         }
     },
     computed: {
@@ -155,6 +159,7 @@ export const Tag = {
         style() {
             const base = {};
             if (this.colorHex) base["background-color"] = this.colorHex;
+            if (this.textColor) base.color = this.textColor;
             return base;
         }
     },

--- a/vue/components/ui/atoms/tag/tag.vue
+++ b/vue/components/ui/atoms/tag/tag.vue
@@ -139,13 +139,13 @@ export const Tag = {
             type: String,
             default: null
         },
-        subtle: {
-            type: Boolean,
-            default: true
-        },
         textColor: {
             type: String,
             default: null
+        },
+        subtle: {
+            type: Boolean,
+            default: true
         }
     },
     computed: {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-pulse/issues/296 |
| Dependencies | -- |
| Decisions | Add `textColor` prop to `tag` component |
| Screenshot | ![imagem](https://user-images.githubusercontent.com/22588915/152849760-774177d0-c7c7-4809-974e-0df459c10fca.png) |
