### PR TITLE
#296 Add `backgroundColor` prop to `progress-bar` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Added variant "white" to `input-image`
+* Added prop `backgroundColor` to `progress-bar` component to allow customizing the progress bar background color - [#296](https://github.com/ripe-tech/ripe-pulse/issues/296)
 
 ### Changed
 

--- a/vue/components/ui/molecules/progress-bar/progress-bar.vue
+++ b/vue/components/ui/molecules/progress-bar/progress-bar.vue
@@ -83,7 +83,7 @@ export const ProgressBar = {
         },
         progressBarStyle() {
             const base = {};
-            if (this.backgroundColor) base["background-color"] = this.backgroundColor;
+            if (this.backgroundColor) base.backgroundColor = this.backgroundColor;
             return base;
         },
         fillStyle() {

--- a/vue/components/ui/molecules/progress-bar/progress-bar.vue
+++ b/vue/components/ui/molecules/progress-bar/progress-bar.vue
@@ -3,7 +3,7 @@
         <p class="label" v-bind:style="labelStyle" v-if="label">
             {{ label }}
         </p>
-        <div class="progress-bar">
+        <div class="progress-bar" v-bind:style="progressBarStyle">
             <div class="fill" v-bind:style="fillStyle" />
         </div>
     </div>
@@ -44,6 +44,10 @@ export const ProgressBar = {
             type: String,
             default: null
         },
+        backgroundColor: {
+            type: String,
+            default: null
+        },
         steps: {
             type: Number,
             default: 3
@@ -75,6 +79,11 @@ export const ProgressBar = {
                 color: this.color,
                 "text-align": this.labelAlignment
             };
+            return base;
+        },
+        progressBarStyle() {
+            const base = {};
+            if (this.backgroundColor) base["background-color"] = this.backgroundColor;
             return base;
         },
         fillStyle() {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-pulse/issues/296 |
| Dependencies | -- |
| Decisions | Add `backgroundColor` prop to `progress-bar` component |
| Screenshot | ![imagem](https://user-images.githubusercontent.com/22588915/152852880-623e5f66-bcc8-42b4-ba4a-8fbadc7198f1.png) |
