### PR TITLE
fix: removed href from dropdown story

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Webpack configuration for using source "raw" contents of some files 
+* Remove `href` from `dropdown` stories that caused the site to open inside the storybook and break navigation
 
 ## [0.18.1] - 2022-02-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Webpack configuration for using source "raw" contents of some files 
 * Remove `href` from `dropdown` stories that caused the site to open inside the storybook and break navigation
+* Fixed `process/browser` alias webpack configuration for webpack@5
 
 ## [0.18.1] - 2022-02-08
 

--- a/vue/components/ui/atoms/dropdown/dropdown.stories.js
+++ b/vue/components/ui/atoms/dropdown/dropdown.stories.js
@@ -56,7 +56,7 @@ storiesOf("Components/Atoms/Dropdown", module)
                     },
                     {
                         value: "text_platforme",
-                        href: "https://www.platforme.com"
+                        href: "#"
                     },
                     {
                         value: "text_platforme_blank",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,10 +38,7 @@ const config = {
         new ESLintPlugin({
             extensions: ["js", "jsx", "vue"]
         }),
-        new webpack.BannerPlugin(banner),
-        new webpack.ProvidePlugin({
-            process: "process/browser"
-        })
+        new webpack.BannerPlugin(banner)
     ],
     module: {
         rules: [
@@ -136,7 +133,8 @@ const config = {
     resolve: {
         alias: {
             base$: "../../../js",
-            vue$: "vue/dist/vue.esm.js"
+            vue$: "vue/dist/vue.esm.js",
+            process: "process/browser"
         },
         fallback: {
             fs: false,


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-white/pull/965#discussion_r805148458 |
| Dependencies | -- |
| Decisions | - Removed `href` from `dropdown` stories that caused the site to open inside the storybook and break navigation |
| Animated GIF | -- |
