### PR TITLE
fix: apply correctly the border radius in `image-item`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Webpack configuration for using source "raw" contents of some files 
 * Remove `href` from `dropdown` stories that caused the site to open inside the storybook and break navigation
 * Fixed `process/browser` alias webpack configuration for webpack@5
+* Apply correctly the border radius in `image-item`
 
 ## [0.18.1] - 2022-02-08
 

--- a/vue/components/ui/atoms/image-item/image-item.vue
+++ b/vue/components/ui/atoms/image-item/image-item.vue
@@ -95,9 +95,11 @@
     background-color: $soft-blue;
     border: 1px solid $light-white;
     border-radius: 10px;
+    box-sizing: border-box;
     display: flex;
     height: 260px;
     justify-content: center;
+    overflow: hidden;
     transition: border-color 0.15s ease-out, box-shadow 0.15s ease-out, transform 0.15s ease-out;
     user-select: none;
     width: 214px;
@@ -254,14 +256,13 @@ export const ImageItem = {
             const base = {};
             if (this.height) base.height = `${this.height}px`;
             if (this.width) base.width = `${this.width}px`;
-            if (this.imageObjectFit) base.objectFit = this.imageObjectFit;
             if (this.selected) base.border = `1px solid ${this.selectedColor}`;
             return base;
         },
         imageStyle() {
             const base = {};
-            if (this.height) base.height = `${this.height}px`;
-            if (this.width) base.width = `${this.width}px`;
+            if (this.height) base.height = `${this.height - 1}px`;
+            if (this.width) base.width = `${this.width - 1}px`;
             if (this.imageObjectFit) base.objectFit = this.imageObjectFit;
             return base;
         },

--- a/vue/components/ui/atoms/image-item/image-item.vue
+++ b/vue/components/ui/atoms/image-item/image-item.vue
@@ -254,15 +254,15 @@ export const ImageItem = {
         },
         itemImageStyle() {
             const base = {};
-            if (this.height) base.height = `${this.height}px`;
-            if (this.width) base.width = `${this.width}px`;
+            if (this.height) base.height = `${this.height + 2}px`;
+            if (this.width) base.width = `${this.width + 2}px`;
             if (this.selected) base.border = `1px solid ${this.selectedColor}`;
             return base;
         },
         imageStyle() {
             const base = {};
-            if (this.height) base.height = `${this.height - 1}px`;
-            if (this.width) base.width = `${this.width - 1}px`;
+            if (this.height) base.height = `${this.height}px`;
+            if (this.width) base.width = `${this.width}px`;
             if (this.imageObjectFit) base.objectFit = this.imageObjectFit;
             return base;
         },


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | The image did not have border radius applied:<br>![image](https://user-images.githubusercontent.com/25725586/154309315-5f7403d8-c996-461d-9b18-69a19ebc86b9.png)<br>Can be seen in `ripe-util-vue`'s storybook:<br>![image](https://user-images.githubusercontent.com/25725586/154309486-edff9e62-45e7-4b08-b2b8-bfc036616834.png) |
| Dependencies | |
| Decisions | - Add `overflow: hidden` and `box-sizing: border-box` to `image-item` styling and reduce the image size by `1px` so that the border can be seen |
| Animated GIF | Now:<br>![image](https://user-images.githubusercontent.com/25725586/154309196-b90793db-113c-4060-909b-5f2f5f730c17.png)<br>![image](https://user-images.githubusercontent.com/25725586/154309603-b365eab7-39dd-4827-a50d-de9a5fcffece.png)|
