### PR TITLE
fix: table sort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Remove `href` from `dropdown` stories that caused the site to open inside the storybook and break navigation
 * Fixed `process/browser` alias webpack configuration for webpack@5
 * Apply correctly the border radius in `image-item`
-* Sorting two table elements with same value for sorting key gives priority to first element
+* Sorting two table elements with same value returns 0 for cross browser compatibility
 
 ## [0.18.1] - 2022-02-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Remove `href` from `dropdown` stories that caused the site to open inside the storybook and break navigation
 * Fixed `process/browser` alias webpack configuration for webpack@5
 * Apply correctly the border radius in `image-item`
+* Sorting two table elements with same value for sorting key gives priority to first element
 
 ## [0.18.1] - 2022-02-08
 

--- a/vue/components/ui/molecules/table-expandable/table-expandable.vue
+++ b/vue/components/ui/molecules/table-expandable/table-expandable.vue
@@ -99,6 +99,7 @@ export const TableExpandable = {
             type: Function,
             default: (items, column, reverse) => {
                 return items.sort((first, second) => {
+                    if (first[column] === second[column]) return 0;
                     const order = reverse ? -1 : 1;
                     const sort = first[column] > second[column];
                     return order * (sort ? 1 : -1);

--- a/vue/components/ui/molecules/table/table.vue
+++ b/vue/components/ui/molecules/table/table.vue
@@ -329,7 +329,7 @@ export const Table = {
             default: (items, column, reverse) => {
                 return items.sort((first, second) => {
                     const order = reverse ? -1 : 1;
-                    const sort = first[column] > second[column];
+                    const sort = first[column] >= second[column];
                     return order * (sort ? 1 : -1);
                 });
             }

--- a/vue/components/ui/molecules/table/table.vue
+++ b/vue/components/ui/molecules/table/table.vue
@@ -329,8 +329,9 @@ export const Table = {
             default: (items, column, reverse) => {
                 return items.sort((first, second) => {
                     const order = reverse ? -1 : 1;
-                    const sort = first[column] >= second[column];
-                    return order * (sort ? 1 : -1);
+                    if (first[column] > second[column]) return 1 * order;
+                    else if (first[column] < second[column]) return -1 * order;
+                    return 0;
                 });
             }
         },

--- a/vue/components/ui/molecules/table/table.vue
+++ b/vue/components/ui/molecules/table/table.vue
@@ -328,10 +328,10 @@ export const Table = {
             type: Function,
             default: (items, column, reverse) => {
                 return items.sort((first, second) => {
+                    if (first[column] === second[column]) return 0;
                     const order = reverse ? -1 : 1;
-                    if (first[column] > second[column]) return 1 * order;
-                    else if (first[column] < second[column]) return -1 * order;
-                    return 0;
+                    const sort = first[column] > second[column];
+                    return order * (sort ? 1 : -1);
                 });
             }
         },

--- a/vue/components/ui/organisms/table-menu/table-menu.vue
+++ b/vue/components/ui/organisms/table-menu/table-menu.vue
@@ -182,6 +182,7 @@ export const TableMenu = {
             type: Function,
             default: (items, column, reverse) => {
                 return items.sort((first, second) => {
+                    if (first[column] === second[column]) return 0;
                     const order = reverse ? -1 : 1;
                     const sort = first[column] > second[column];
                     return order * (sort ? 1 : -1);


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-core/issues/4659 |
| Dependencies | -- |
| Decisions | If the sorting value is equal for both, we should give priority to the first element. For example, pulse states with same timestamp (due to simultaneous multiple transitions). |
| Animated GIF | ![Peek 2022-02-28 12-36](https://user-images.githubusercontent.com/16060539/155984895-3f9e8a4e-d6c6-4f75-a89c-e7cd622572c2.gif) |
