### PR TITLE
Added Expandable Section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added `section-expandable-ripe` component - [#247](https://github.com/ripe-tech/ripe-util-vue/issues/247)
 * Added variant "white" to `input-image`
 * Added `section-ripe` component - [#281](https://github.com/ripe-tech/ripe-pulse/issues/281)
 

--- a/vue/components/ui/molecules/index.js
+++ b/vue/components/ui/molecules/index.js
@@ -34,6 +34,7 @@ import { ProgressListItem } from "./progress-list-item/progress-list-item.vue";
 import { RadioGroup } from "./radio-group/radio-group.vue";
 import { Search } from "./search/search.vue";
 import { Section } from "./section/section.vue";
+import { SectionExpandable } from "./section-expandable/section-expandable.vue";
 import { Select } from "./select/select.vue";
 import { SelectCheckboxes } from "./select-checkboxes/select-checkboxes.vue";
 import { SelectList } from "./select-list/select-list.vue";
@@ -82,6 +83,7 @@ const install = Vue => {
     Vue.component("progress-list-item", ProgressListItem);
     Vue.component("radio-group", RadioGroup);
     Vue.component("search", Search);
+    Vue.component("section-expandable-ripe", SectionExpandable);
     Vue.component("section-ripe", Section);
     Vue.component("select-ripe", Select);
     Vue.component("select-checkboxes", SelectCheckboxes);
@@ -132,6 +134,7 @@ export {
     RadioGroup,
     Search,
     Section,
+    SectionExpandable,
     Select,
     SelectCheckboxes,
     SelectList,

--- a/vue/components/ui/molecules/section-expandable/assets/arrow-down.svg
+++ b/vue/components/ui/molecules/section-expandable/assets/arrow-down.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="17"><path d="M11.825 7 8 10.817 4.175 7 3 8.175l5 5 5-5z" fill-rule="evenodd"/></svg>

--- a/vue/components/ui/molecules/section-expandable/index.js
+++ b/vue/components/ui/molecules/section-expandable/index.js
@@ -1,0 +1,1 @@
+export { SectionExpandable } from "./section-expandable.vue";

--- a/vue/components/ui/molecules/section-expandable/section-expandable.stories.js
+++ b/vue/components/ui/molecules/section-expandable/section-expandable.stories.js
@@ -1,17 +1,18 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, text } from "@storybook/addon-knobs";
 
-storiesOf("Components/Molecules/Section", module)
+storiesOf("Components/Molecules/Section Expandable", module)
     .addDecorator(withKnobs)
     .add("Section Expandable", () => ({
         props: {
             title: {
-                default: text("Title", "Section title")
+                default: text("Title", "Expandable Section Title")
             }
         },
         template: `
-            <section-ripe
-                v-bind:title="title"
-            />
+            <section-expandable-ripe v-bind:title="title">
+                <h3> This is some text inside the expandable section. </h3>
+                <p> And some smaller text. </p>
+            </section-expandable-ripe>
         `
     }));

--- a/vue/components/ui/molecules/section-expandable/section-expandable.stories.js
+++ b/vue/components/ui/molecules/section-expandable/section-expandable.stories.js
@@ -1,0 +1,17 @@
+import { storiesOf } from "@storybook/vue";
+import { withKnobs, text } from "@storybook/addon-knobs";
+
+storiesOf("Components/Molecules/Section", module)
+    .addDecorator(withKnobs)
+    .add("Section Expandable", () => ({
+        props: {
+            title: {
+                default: text("Title", "Section title")
+            }
+        },
+        template: `
+            <section-ripe
+                v-bind:title="title"
+            />
+        `
+    }));

--- a/vue/components/ui/molecules/section-expandable/section-expandable.vue
+++ b/vue/components/ui/molecules/section-expandable/section-expandable.vue
@@ -1,19 +1,25 @@
 <template>
-    <div class="section-expandable">
-        <p>mequie</p>
-        <div class="title" v-if="title">
-            <slot name="title">
-                {{ title }}
-            </slot>
+    <div
+        class="section-expandable"
+        v-on:click="onSectionClick"
+    >
+        <div class="header">
+            <div class="title" v-if="title">
+                <slot name="title">
+                    {{ title }}
+                </slot>
+            </div>
+            <icon
+                v-bind:icon="expanded ? 'chevron-up' : 'chevron-down'"
+                v-bind:color="'#c2c7cc'"
+                v-bind:width="20"
+                v-bind:height="20"
+            />
         </div>
-        <p>vivvas</p>
-        <icon
-            v-bind:icon="isExpanded ? 'chevron-up' : 'chevron-down'"
-            v-bind:color="'#c2c7cc'"
-            v-bind:width="20"
-            v-bind:height="20"
-        />
-        <div class="content" v-if="isExpanded">
+        <div
+            class="content"
+            ref="content"
+        >
             <slot />
         </div>
     </div>
@@ -28,24 +34,40 @@
     padding-top: 24px;
 }
 
-.section-expandable > .title {
+.section-expandable > .header {
+    display: flex;
+}
+
+.section-expandable > .header > .title {
     color: $black;
     font-size: 16px;
     font-weight: 600;
     letter-spacing: 0.35px;
-    margin-bottom: 30px;
     text-transform: uppercase;
 }
 
-.section-expandable > .content > .form-input,
-.section-expandable > .description {
+.section-expandable > .header > .icon {
+    margin-left: auto;
+}
+
+.section-expandable > .content > .description {
     margin-bottom: 24px;
-    margin-top: 0px;
+    margin-top: 30px;
+}
+
+.section-expandable > .content > .form-input {
+    margin-bottom: 24px;
 }
 
 .section-expandable > .content > .form-input:last-child,
 .section-expandable > .description:last-child {
     margin-bottom: 0px;
+}
+
+.section-expandable > .content {
+    max-height: 0px;
+    overflow: hidden;
+    transition: max-height 0.25s cubic-bezier(0.645, 0.045, 0.355, 1);
 }
 </style>
 
@@ -54,7 +76,8 @@ export const SectionExpandable = {
     name: "section-expandable-ripe",
     data: function() {
         return {
-            isExpanded: false
+            expanded: false,
+            expandedHeight: null
         };
     },
     props: {
@@ -65,6 +88,30 @@ export const SectionExpandable = {
         items: {
             type: Array,
             default: () => []
+        }
+    },
+    methods: {
+        onSectionClick() {
+            this.expanded = !this.expanded;
+            const content = this.$refs.content;
+
+            if (content && this.expanded) {
+                content.style.maxHeight = `${this.expandedHeight}px`;
+            } else if (content) {
+                content.style.maxHeight = "0px";
+            }
+        }
+    },
+    mounted() {
+        // gets the expanded height of the content
+        const content = this.$refs.content;
+        if (content && this.expandedHeight === null) {
+            content.style.maxHeight = "none";
+            try {
+                this.expandedHeight = content.offsetHeight;
+            } finally {
+                content.style.maxHeight = "0px";
+            }
         }
     }
 };

--- a/vue/components/ui/molecules/section-expandable/section-expandable.vue
+++ b/vue/components/ui/molecules/section-expandable/section-expandable.vue
@@ -1,0 +1,73 @@
+<template>
+    <div class="section-expandable">
+        <p>mequie</p>
+        <div class="title" v-if="title">
+            <slot name="title">
+                {{ title }}
+            </slot>
+        </div>
+        <p>vivvas</p>
+        <icon
+            v-bind:icon="isExpanded ? 'chevron-up' : 'chevron-down'"
+            v-bind:color="'#c2c7cc'"
+            v-bind:width="20"
+            v-bind:height="20"
+        />
+        <div class="content" v-if="isExpanded">
+            <slot />
+        </div>
+    </div>
+</template>
+
+<style lang="scss" scoped>
+@import "css/colors.scss";
+
+.section-expandable {
+    border-top: 1px solid $light-white;
+    padding-bottom: 24px;
+    padding-top: 24px;
+}
+
+.section-expandable > .title {
+    color: $black;
+    font-size: 16px;
+    font-weight: 600;
+    letter-spacing: 0.35px;
+    margin-bottom: 30px;
+    text-transform: uppercase;
+}
+
+.section-expandable > .content > .form-input,
+.section-expandable > .description {
+    margin-bottom: 24px;
+    margin-top: 0px;
+}
+
+.section-expandable > .content > .form-input:last-child,
+.section-expandable > .description:last-child {
+    margin-bottom: 0px;
+}
+</style>
+
+<script>
+export const SectionExpandable = {
+    name: "section-expandable-ripe",
+    data: function() {
+        return {
+            isExpanded: false
+        };
+    },
+    props: {
+        title: {
+            type: String,
+            default: null
+        },
+        items: {
+            type: Array,
+            default: () => []
+        }
+    }
+};
+
+export default SectionExpandable;
+</script>

--- a/vue/components/ui/molecules/section-expandable/section-expandable.vue
+++ b/vue/components/ui/molecules/section-expandable/section-expandable.vue
@@ -50,17 +50,14 @@
     margin-left: auto;
 }
 
-.section-expandable > .content > .description {
-    margin-bottom: 24px;
+.section-expandable > .content > .description:first-child,
+.section-expandable > .content > .form-input:first-child {
     margin-top: 30px;
 }
 
-.section-expandable > .content > .form-input {
-    margin-bottom: 24px;
-}
-
-.section-expandable > .content > .form-input:last-child,
-.section-expandable > .description:last-child {
+.section-expandable > .content > .form-input,
+.section-expandable > .content > .description {
+    margin-top: 24px;
     margin-bottom: 0px;
 }
 

--- a/vue/components/ui/molecules/section-expandable/section-expandable.vue
+++ b/vue/components/ui/molecules/section-expandable/section-expandable.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="section-expandable">
-        <div 
+        <div
             class="header"
             v-on:click="onSectionClick"
         >
@@ -57,8 +57,8 @@
 
 .section-expandable > .content > .form-input,
 .section-expandable > .content > .description {
-    margin-top: 24px;
     margin-bottom: 0px;
+    margin-top: 24px;
 }
 
 .section-expandable > .content {
@@ -99,7 +99,7 @@ export const SectionExpandable = {
             }
         }
     },
-    mounted() {
+    mounted: function() {
         // gets the expanded height of the content
         const content = this.$refs.content;
         if (content && this.expandedHeight === null) {

--- a/vue/components/ui/molecules/section-expandable/section-expandable.vue
+++ b/vue/components/ui/molecules/section-expandable/section-expandable.vue
@@ -1,9 +1,6 @@
 <template>
     <div class="section-expandable">
-        <div
-            class="header"
-            v-on:click="onSectionClick"
-        >
+        <div class="header" v-on:click="onSectionClick">
             <div class="title" v-if="title">
                 <slot name="title">
                     {{ title }}
@@ -16,10 +13,7 @@
                 v-bind:height="20"
             />
         </div>
-        <div
-            class="content"
-            ref="content"
-        >
+        <div class="content" ref="content">
             <slot />
         </div>
     </div>
@@ -81,13 +75,23 @@ export const SectionExpandable = {
         title: {
             type: String,
             default: null
-        },
-        items: {
-            type: Array,
-            default: () => []
         }
     },
+    mounted: function() {
+        this.calculateOffsetHeight();
+    },
     methods: {
+        calculateOffsetHeight() {
+            const content = this.$refs.content;
+            if (content && this.expandedHeight === null) {
+                content.style.maxHeight = "none";
+                try {
+                    this.expandedHeight = content.offsetHeight;
+                } finally {
+                    content.style.maxHeight = "0px";
+                }
+            }
+        },
         onSectionClick() {
             this.expanded = !this.expanded;
             const content = this.$refs.content;
@@ -95,18 +99,6 @@ export const SectionExpandable = {
             if (content && this.expanded) {
                 content.style.maxHeight = `${this.expandedHeight}px`;
             } else if (content) {
-                content.style.maxHeight = "0px";
-            }
-        }
-    },
-    mounted: function() {
-        // gets the expanded height of the content
-        const content = this.$refs.content;
-        if (content && this.expandedHeight === null) {
-            content.style.maxHeight = "none";
-            try {
-                this.expandedHeight = content.offsetHeight;
-            } finally {
                 content.style.maxHeight = "0px";
             }
         }

--- a/vue/components/ui/molecules/section-expandable/section-expandable.vue
+++ b/vue/components/ui/molecules/section-expandable/section-expandable.vue
@@ -1,9 +1,9 @@
 <template>
-    <div
-        class="section-expandable"
-        v-on:click="onSectionClick"
-    >
-        <div class="header">
+    <div class="section-expandable">
+        <div 
+            class="header"
+            v-on:click="onSectionClick"
+        >
             <div class="title" v-if="title">
                 <slot name="title">
                     {{ title }}

--- a/vue/components/ui/molecules/section-expandable/section-expandable.vue
+++ b/vue/components/ui/molecules/section-expandable/section-expandable.vue
@@ -83,6 +83,7 @@ export const SectionExpandable = {
     methods: {
         calculateOffsetHeight() {
             const content = this.$refs.content;
+
             if (content && this.expandedHeight === null) {
                 content.style.maxHeight = "none";
                 try {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Requested in the issue https://github.com/ripe-tech/ripe-util-vue/issues/247 |
| Decisions | There was a need to a section that could be collapsed or expanded at will. This PR adds a new `section-expandable-ripe` component, that is similar to the basic `section` component, with the extra logic for the collapse of information. |
| Screenshots | ![Screen Recording 2022-02-28 at 17 17 16](https://user-images.githubusercontent.com/22790704/156029306-03f57ffb-54ef-4c4f-96d8-3b31d5db399a.gif) Don't know why it's in slow-motion, but it's in regular speed when using! |