### PR TITLE
Improved feature set for tooltips

### DIFF
--- a/vue/components/ui/molecules/form-input/form-input.stories.js
+++ b/vue/components/ui/molecules/form-input/form-input.stories.js
@@ -18,6 +18,9 @@ storiesOf("Components/Molecules/Form Input", module)
             header: {
                 default: text("Header", "Header")
             },
+            tooltipText: {
+                default: text("Tooltip Text", "Tooltip Text")
+            },
             alignment: {
                 default: select(
                     "Alignment",
@@ -92,6 +95,7 @@ storiesOf("Components/Molecules/Form Input", module)
                 v-bind:variant="variant"
                 v-bind:alignment="alignment"
                 v-bind:header="header"
+                v-bind:tooltip-text="tooltipText"
                 v-bind:footer="footer"
                 v-bind:header-variant="headerVariant"
                 v-bind:header-size="headerSize"

--- a/vue/components/ui/molecules/form-input/form-input.vue
+++ b/vue/components/ui/molecules/form-input/form-input.vue
@@ -158,7 +158,7 @@ export const FormInput = {
         },
         tooltipText: {
             type: String,
-            default: "example"
+            default: null
         },
         tooltipProps: {
             type: Object,

--- a/vue/components/ui/molecules/form-input/form-input.vue
+++ b/vue/components/ui/molecules/form-input/form-input.vue
@@ -1,7 +1,14 @@
 <template>
     <div class="form-input" v-bind:class="classes">
         <slot name="header">
-            <tooltip v-bind="tooltipProps" v-if="tooltip">
+            <tooltip
+                v-bind="{
+                    text: tooltipText,
+                    orientation: 'top',
+                    ...tooltipProps
+                }"
+                v-if="tooltipText"
+            >
                 <label-ripe class="header" v-bind="headerProps" v-if="header" />
             </tooltip>
             <label-ripe class="header" v-bind="headerProps" v-else-if="header" />
@@ -66,6 +73,11 @@
 .form-input .header.success,
 .form-input .footer.success {
     color: $success;
+}
+
+.form-input .tooltip > .header {
+    text-decoration: underline #57626e dashed;
+    text-underline-offset: 3px;
 }
 
 .form-input .header {
@@ -144,13 +156,13 @@ export const FormInput = {
             type: Number,
             default: null
         },
-        tooltip: {
-            type: Boolean,
-            default: false
+        tooltipText: {
+            type: String,
+            default: "example"
         },
         tooltipProps: {
             type: Object,
-            default: {}
+            default: () => ({})
         }
     },
     computed: {
@@ -173,6 +185,11 @@ export const FormInput = {
             if (this.headerVariant) base[`${this.headerVariant}`] = true;
             return base;
         },
+        footerClasses() {
+            const base = {};
+            if (this.footerVariant) base[`${this.footerVariant}`] = true;
+            return base;
+        },
         headerProps() {
             return {
                 style: this.headerStyle,
@@ -181,11 +198,6 @@ export const FormInput = {
                 text: this.header,
                 for: this.id
             };
-        },
-        footerClasses() {
-            const base = {};
-            if (this.footerVariant) base[`${this.footerVariant}`] = true;
-            return base;
         }
     }
 };

--- a/vue/components/ui/molecules/form-input/form-input.vue
+++ b/vue/components/ui/molecules/form-input/form-input.vue
@@ -1,15 +1,10 @@
 <template>
     <div class="form-input" v-bind:class="classes">
         <slot name="header">
-            <label-ripe
-                class="header"
-                v-bind:style="headerStyle"
-                v-bind:class="headerClasses"
-                v-bind:size="headerSize"
-                v-bind:text="header"
-                v-bind:for="id"
-                v-if="header"
-            />
+            <tooltip v-bind="tooltipProps" v-if="tooltip">
+                <label-ripe class="header" v-bind="headerProps" v-if="header" />
+            </tooltip>
+            <label-ripe class="header" v-bind="headerProps" v-else-if="header" />
         </slot>
         <div class="flex-container">
             <div class="content">
@@ -148,6 +143,14 @@ export const FormInput = {
         footerMinWidth: {
             type: Number,
             default: null
+        },
+        tooltip: {
+            type: Boolean,
+            default: false
+        },
+        tooltipProps: {
+            type: Object,
+            default: {}
         }
     },
     computed: {
@@ -169,6 +172,15 @@ export const FormInput = {
             const base = {};
             if (this.headerVariant) base[`${this.headerVariant}`] = true;
             return base;
+        },
+        headerProps() {
+            return {
+                style: this.headerStyle,
+                class: this.headerClasses,
+                size: this.headerSize,
+                text: this.header,
+                for: this.id
+            };
         },
         footerClasses() {
             const base = {};

--- a/vue/components/ui/molecules/form-input/form-input.vue
+++ b/vue/components/ui/molecules/form-input/form-input.vue
@@ -3,11 +3,11 @@
         <slot name="header">
             <tooltip
                 v-bind="{
-                    text: tooltipText,
+                    text: tooltipProps.text,
                     orientation: 'top',
                     ...tooltipProps
                 }"
-                v-if="tooltipText"
+                v-if="tooltipText || tooltipProps"
             >
                 <label-ripe class="header" v-bind="headerProps" v-if="header" />
             </tooltip>

--- a/vue/components/ui/molecules/form-input/form-input.vue
+++ b/vue/components/ui/molecules/form-input/form-input.vue
@@ -75,11 +75,6 @@
     color: $success;
 }
 
-.form-input .tooltip > .header {
-    text-decoration: underline #57626e dashed;
-    text-underline-offset: 3px;
-}
-
 .form-input .header {
     margin-bottom: 6px;
 }

--- a/vue/components/ui/molecules/tooltip/tooltip.vue
+++ b/vue/components/ui/molecules/tooltip/tooltip.vue
@@ -46,6 +46,11 @@
     position: relative;
 }
 
+.tooltip-custom.clickable {
+    text-decoration-line: underline;
+    text-decoration-style: dotted;
+}
+
 .tooltip-custom > .tooltip-inner {
     background-color: $dark;
     box-shadow: 0px 0px 16px rgba(45, 58, 70, 0.25);

--- a/vue/components/ui/molecules/tooltip/tooltip.vue
+++ b/vue/components/ui/molecules/tooltip/tooltip.vue
@@ -54,6 +54,10 @@
     z-index: 1;
 }
 
+.tooltip-custom.clickable > .tooltip-inner {
+    pointer-events: auto;
+}
+
 body.round .tooltip-custom > .tooltip-inner {
     border-radius: 4px 4px 4px 4px;
 }
@@ -233,28 +237,6 @@ export const Tooltip = {
         }
     },
     computed: {
-        richText() {
-            let parsed = "";
-            const italicStrings = this.text.split("__");
-            for (let i = 0; i < italicStrings.length; i++) {
-                // only affect even pairs
-                if (i % 2 !== 0) parsed += italicStrings[i] + " ";
-
-                parsed += "<i>" + italicStrings[i] + "</i> ";
-            }
-
-            const boldStrings = parsed.split("**");
-            for (let i = 0; i < boldStrings.length; i++) {
-                // only affect even pairs
-                if (i % 2 !== 0) parsed += boldStrings[i] + " ";
-
-                parsed += "<b>" + boldStrings[i] + "</b> ";
-            }
-
-            console.log("parsed text", parsed);
-
-            return parsed;
-        },
         tooltipInnerStyle() {
             const base = {};
             if (this.width) base.width = `${this.width}px`;
@@ -276,6 +258,8 @@ export const Tooltip = {
             if (this.orientation) {
                 base["tooltip-orientation-" + this.orientation] = this.orientation;
             }
+            if (this.clickable) base["clickable"] = true;
+
             return base;
         }
     },

--- a/vue/components/ui/molecules/tooltip/tooltip.vue
+++ b/vue/components/ui/molecules/tooltip/tooltip.vue
@@ -13,8 +13,8 @@
         <transition v-bind:name="animationData">
             <div class="tooltip-inner" v-bind:style="tooltipInnerStyle" v-show="visibleData">
                 <slot name="tooltip-content">
-                    <div class="tooltip-text" v-bind:style="tooltipTextStyle">
-                        {{ text }}
+                    <div v-bind:style="tooltipTextStyle" class="tooltip-text" v-html="richText">
+                        {{ richText }}
                     </div>
                 </slot>
                 <div class="tip" />
@@ -147,6 +147,10 @@ export const Tooltip = {
             type: Boolean,
             default: false
         },
+        clickable: {
+            type: Boolean,
+            default: false
+        },
         text: {
             type: String,
             default: null
@@ -229,6 +233,28 @@ export const Tooltip = {
         }
     },
     computed: {
+        richText() {
+            let parsed = "";
+            const italicStrings = this.text.split("__");
+            for (let i = 0; i < italicStrings.length; i++) {
+                // only affect even pairs
+                if (i % 2 !== 0) parsed += italicStrings[i] + " ";
+
+                parsed += "<i>" + italicStrings[i] + "</i> ";
+            }
+
+            const boldStrings = parsed.split("**");
+            for (let i = 0; i < boldStrings.length; i++) {
+                // only affect even pairs
+                if (i % 2 !== 0) parsed += boldStrings[i] + " ";
+
+                parsed += "<b>" + boldStrings[i] + "</b> ";
+            }
+
+            console.log("parsed text", parsed);
+
+            return parsed;
+        },
         tooltipInnerStyle() {
             const base = {};
             if (this.width) base.width = `${this.width}px`;

--- a/vue/components/ui/molecules/tooltip/tooltip.vue
+++ b/vue/components/ui/molecules/tooltip/tooltip.vue
@@ -269,9 +269,8 @@ export const Tooltip = {
             if (this.whiteSpace) base["white-space"] = this.whiteSpace;
             if (this.delayData) base["transition-delay"] = `${this.delayData}ms`;
             if (this.durationData) base["transition-duration"] = `${this.durationData}ms`;
-            if (this.alignment)
+            if (!this.alignment) return base;
 
-            { if (!this.alignment) return base; }
             const offset = this.alignment === "top" || this.alignment === "bottom" ? this.baseHeight : this.baseWidth;
             base[this.alignment] = "calc(100% - " + offset + "px)";
 

--- a/vue/components/ui/organisms/form/form.vue
+++ b/vue/components/ui/organisms/form/form.vue
@@ -23,7 +23,6 @@
                                 v-bind:header="
                                     field.label !== undefined ? field.label : field.value
                                 "
-                                v-bind:tooltip-text="field.tooltipText"
                                 v-bind:tooltip-props="field.tooltipProps"
                                 v-bind="field.formInputProps"
                                 v-bind:key="field.value"

--- a/vue/components/ui/organisms/form/form.vue
+++ b/vue/components/ui/organisms/form/form.vue
@@ -23,6 +23,8 @@
                                 v-bind:header="
                                     field.label !== undefined ? field.label : field.value
                                 "
+                                v-bind:tooltip-text="field.tooltipText"
+                                v-bind:tooltip-props="field.tooltipProps"
                                 v-bind="field.formInputProps"
                                 v-bind:key="field.value"
                             >


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-white-admin-ui/issues/73 |
| Decisions | The current tooltip implementation didn't feature some tools such as hovering, and clickable links inside. This PR adds the `clickable` property, which determines whether the tooltip can be hovered and clicked. Another key feature is the `alignment` property. This can be `left`, `right`, `top` or `bottom`, and they control how the tooltip will appear relative to its parent element. By omission, it will assume the same behaviour as before, aligned to the centre. This property gives the flexibility for the tooltip to be added to a component inside a form, without overflowing to outside the form, or even the page. The tooltip allows for rich text via HTML injection. The screenshot below shows the output of this text `Click <i><a href='https://github.com/ripe-tech/ripe-white#readme''>here</a></i> to learn more about this feature.`  |
| Screenshots | <img width="280" alt="image" src="https://user-images.githubusercontent.com/22790704/157278892-802d154e-d55f-484e-a01b-a50e8bdddd57.png"> |
