### PR TITLE
#73 - Re-added support for tooltips in a Form Input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-*
+* Add support for `tooltip` in `form-input` - [#73](https://github.com/ripe-tech/ripe-white-admin-ui/issues/73)
 
 ## [0.20.0] - 2022-03-02
 

--- a/vue/components/ui/molecules/form-input/form-input.vue
+++ b/vue/components/ui/molecules/form-input/form-input.vue
@@ -1,15 +1,17 @@
 <template>
     <div class="form-input" v-bind:class="classes">
         <slot name="header">
-            <label-ripe
-                class="header"
-                v-bind:style="headerStyle"
-                v-bind:class="headerClasses"
-                v-bind:size="headerSize"
-                v-bind:text="header"
-                v-bind:for="id"
-                v-if="header"
-            />
+            <tooltip v-bind="{ ...tooltipProps }">
+                <label-ripe
+                    class="header"
+                    v-bind:style="headerStyle"
+                    v-bind:class="headerClasses"
+                    v-bind:size="headerSize"
+                    v-bind:text="header"
+                    v-bind:for="id"
+                    v-if="header"
+                />
+            </tooltip>
         </slot>
         <div class="flex-container">
             <div class="content">
@@ -51,6 +53,12 @@
 
 .form-input.form-input-inline .flex-container {
     flex: 1;
+}
+
+.form-input .header.tooltip {
+    text-decoration-line: underline;
+    text-decoration-style: dashed;
+    text-underline-offset: 3px;
 }
 
 .form-input .header,
@@ -148,6 +156,10 @@ export const FormInput = {
         footerMinWidth: {
             type: Number,
             default: null
+        },
+        tooltipProps: {
+            type: Object,
+            default: null
         }
     },
     computed: {
@@ -168,6 +180,7 @@ export const FormInput = {
         headerClasses() {
             const base = {};
             if (this.headerVariant) base[`${this.headerVariant}`] = true;
+            if (this.tooltipProps) base.tooltip = true;
             return base;
         },
         footerClasses() {

--- a/vue/components/ui/organisms/form/form.vue
+++ b/vue/components/ui/organisms/form/form.vue
@@ -20,6 +20,7 @@
                             <form-input
                                 class="section-field"
                                 v-bind:classes="formInputClasses(field)"
+                                v-bind:tooltip-props="field.tooltipProps"
                                 v-bind:header="
                                     field.label !== undefined ? field.label : field.value
                                 "


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-white-admin-ui/issues/73 |
| Decisions | Support for `tooltip` in a `form-input` component, re-added due to changes in `tooltip` implementation. |
| Screenshots | <img width="243" alt="image" src="https://user-images.githubusercontent.com/22790704/158405009-807466b3-c3d2-4aaf-aff5-1b89beb18e4a.png"> |
