### PR TITLE
#317: Justification translate to human-readable format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* `justificationByCode` mixin method - [ripe-pulse/#317](https://github.com/ripe-tech/ripe-pulse/issues/317)
 
 ### Changed
 

--- a/vue/mixins/ripe.js
+++ b/vue/mixins/ripe.js
@@ -2,6 +2,39 @@ import { hasPermission, toTokensM } from "yonius";
 
 export const ripeMixin = {
     methods: {
+        async justificationByCode({
+            context = null,
+            code = null,
+            codeFull = null,
+            other = "other;"
+        } = {}) {
+            // if the other code is used we return with
+            // the ad-hoc message
+            if (codeFull.includes(other)) {
+                const index = codeFull.indexOf(other);
+                return {
+                    context: "other",
+                    code_full: codeFull,
+                    text: codeFull.slice(index + other.length)
+                };
+            }
+
+            // if a full code is provided we extract
+            // the context and code from it
+            if (codeFull != null) [context, code] = codeFull.split(":");
+
+            // if no context was provided or derived
+            // we can't get the justification and return
+            if (context === null) return null;
+
+            // fetches the justification context and
+            // filters for the code full match
+            const justifications = await this.$ripeApi.getJustificationsByContextP(context);
+            if (!justifications || justifications.length === 0) return null;
+
+            const justification = justifications.find(j => j.code_full === codeFull);
+            return justification !== undefined ? justification : null;
+        },
         toTokensM(tokens) {
             return toTokensM(tokens);
         },


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-pulse/issues/317 |
| Dependencies | -- |
| Decisions | Mixin to fetch translations for justification codes to human-readable format. |

![image](https://user-images.githubusercontent.com/16060539/159314547-9ef7238e-b870-46c5-9f90-1c13c55c5994.png)

![image](https://user-images.githubusercontent.com/16060539/159314052-05138126-f66b-419d-b547-2a0d4b7f8dec.png)

@BeeMargarida  @3rdvision was a bit unsure, maybe this should be moved to:
- commons JS
- or create a new SDK method with core endpoint
- or just leave it as a mixin
