### PR TITLE
#257 Tooltip red variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* Add variant `red` to tooltip - [ripe-util-vue/#257](https://github.com/ripe-tech/ripe-util-vue/issues/257)
 
 ### Changed
 

--- a/vue/components/ui/molecules/tooltip/tooltip.stories.js
+++ b/vue/components/ui/molecules/tooltip/tooltip.stories.js
@@ -21,7 +21,8 @@ storiesOf("Components/Molecules/Tooltip", module)
                         Unset: undefined,
                         Dark: "dark",
                         Grey: "grey",
-                        White: "white"
+                        White: "white",
+                        Red: "red"
                     },
                     undefined
                 )

--- a/vue/components/ui/molecules/tooltip/tooltip.vue
+++ b/vue/components/ui/molecules/tooltip/tooltip.vue
@@ -74,6 +74,11 @@ body.round .tooltip-custom > .tooltip-inner {
     color: $dark;
 }
 
+.tooltip-custom.tooltip-variant-red > .tooltip-inner {
+    background-color: #ae2929;
+    color: $white;
+}
+
 .tooltip-custom.tooltip-orientation-top > .tooltip-inner {
     bottom: calc(100% + 10px);
 }
@@ -134,6 +139,10 @@ body.round .tooltip-custom > .tooltip-inner {
 
 .tooltip-custom.tooltip-variant-white > .tooltip-inner > .tip {
     background: linear-gradient(-45deg, $white 50%, transparent 50%);
+}
+
+.tooltip-custom.tooltip-variant-red > .tooltip-inner > .tip {
+    background: linear-gradient(-45deg, #ae2929 50%, transparent 50%);
 }
 
 .tooltip-custom.tooltip-orientation-top > .tooltip-inner > .tip {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-util-vue/issues/257 |
| Dependencies | -- 
| Decisions | Add `"red"` variant to tooltip |
| Screenshot | ![imagem](https://user-images.githubusercontent.com/22588915/160170964-ce92f149-e7b3-424f-8306-c1392332d41d.png) |
