### PR TITLE
#265 Fix `section-expandable` not handling dynamic content height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-*
+* Fix `section-expandable` not handling dynamic content height changes - [ripe-util-vue/#265](https://github.com/ripe-tech/ripe-util-vue/issues/265)
 
 ## [0.20.2] - 2022-03-23
 

--- a/vue/components/ui/molecules/section-expandable/section-expandable.vue
+++ b/vue/components/ui/molecules/section-expandable/section-expandable.vue
@@ -99,25 +99,22 @@ export const SectionExpandable = {
         }
     },
     mounted: function() {
-        this.calculateOffsetHeight();
+        this.updateExpanded();
+    },
+    updated: function() {
         this.updateExpanded();
     },
     methods: {
-        calculateOffsetHeight() {
-            const content = this.$refs.content;
-            if (content && this.expandedHeight === null) {
-                content.style.maxHeight = "none";
-                try {
-                    this.expandedHeight = content.offsetHeight;
-                } finally {
-                    content.style.maxHeight = "0px";
-                }
-            }
-        },
         updateExpanded() {
             const content = this.$refs.content;
             if (!content) return;
-            content.style.maxHeight = this.expandedData ? `${this.expandedHeight}px` : "0px";
+
+            content.style.maxHeight = "none";
+            try {
+                this.expandedHeight = content.offsetHeight;
+            } finally {
+                content.style.maxHeight = this.expandedData ? `${this.expandedHeight}px` : "0px";
+            }
         },
         onSectionClick() {
             this.expandedData = !this.expandedData;

--- a/vue/components/ui/molecules/section-expandable/section-expandable.vue
+++ b/vue/components/ui/molecules/section-expandable/section-expandable.vue
@@ -94,6 +94,7 @@ export const SectionExpandable = {
         classes() {
             const base = {};
             if (this.animated) base.animated = true;
+            if (this.expandedData) base.expanded = true;
             return base;
         }
     },

--- a/vue/components/ui/molecules/section-expandable/section-expandable.vue
+++ b/vue/components/ui/molecules/section-expandable/section-expandable.vue
@@ -87,45 +87,47 @@ export const SectionExpandable = {
     data: function() {
         return {
             expandedData: this.expanded,
-            expandedHeight: null
+            contentHeight: null
         };
-    },
-    watch: {
-        expanded(value) {
-            this.expandedData = value;
-        },
-        expandedData(value) {
-            this.$emit("update:expanded", value);
-        }
-    },
-    mounted: function() {
-        this.updateExpanded();
-    },
-    updated: function() {
-        this.updateExpanded();
-    },
-    methods: {
-        updateExpanded() {
-            const content = this.$refs.content;
-            if (!content) return;
-
-            content.style.maxHeight = "none";
-            try {
-                this.expandedHeight = content.offsetHeight;
-            } finally {
-                content.style.maxHeight = this.expandedData ? `${this.expandedHeight}px` : "0px";
-            }
-        },
-        onSectionClick() {
-            this.expandedData = !this.expandedData;
-            this.updateExpanded();
-        }
     },
     computed: {
         classes() {
             const base = {};
             if (this.animated) base.animated = true;
             return base;
+        }
+    },
+    watch: {
+        expanded(value) {
+            this.expandedData = value;
+        },
+        expandedData(value) {
+            this.updateExpanded();
+            this.$emit("update:expanded", value);
+        },
+        contentHeight(value) {
+            this.updateExpanded();
+        }
+    },
+    mounted: function() {
+        this.calculateContentHeight();
+    },
+    updated: function() {
+        this.calculateContentHeight();
+    },
+    methods: {
+        calculateContentHeight() {
+            const content = this.$refs.content;
+            if (!content) return;
+            this.contentHeight = content.scrollHeight;
+        },
+        updateExpanded() {
+            const content = this.$refs.content;
+            if (!content) return;
+            content.style.maxHeight = this.expandedData ? `${this.contentHeight}px` : "0px";
+        },
+        onSectionClick() {
+            this.expandedData = !this.expandedData;
         }
     }
 };


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-util-vue/issues/265 |
| Dependencies | -- |
| Decisions | Fix `section-expandable` not handling dynamic content height changes |

https://user-images.githubusercontent.com/22588915/161044423-f0643e30-8477-4797-8401-53907d7a4585.mp4
