### PR TITLE
feat: disabled button icon dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Add variant `red` to tooltip - [ripe-util-vue/#257](https://github.com/ripe-tech/ripe-util-vue/issues/257)
 * Support `expanded` prop in `section-expandable` component - [ripe-util-vue/#265](https://github.com/ripe-tech/ripe-util-vue/issues/265)
+* Prop to disable the button icon dropdown component - [ripe-pulse/#281](https://github.com/ripe-tech/ripe-pulse/issues/281)
 
 ### Changed
 

--- a/vue/components/ui/molecules/button-icon-dropdown/button-icon-dropdown.stories.js
+++ b/vue/components/ui/molecules/button-icon-dropdown/button-icon-dropdown.stories.js
@@ -30,11 +30,12 @@ storiesOf("Components/Molecules/Button Icon Dropdown", module)
                         target: "_blank"
                     }
                 ]
-            }
+            },
+            disabled: false
         },
         template: `
             <div>
-                <button-icon-dropdown v-bind:items="items" />
+                <button-icon-dropdown v-bind:items="items" v-bind:disabled="disabled" />
             </div>
         `
     }));

--- a/vue/components/ui/molecules/button-icon-dropdown/button-icon-dropdown.stories.js
+++ b/vue/components/ui/molecules/button-icon-dropdown/button-icon-dropdown.stories.js
@@ -1,5 +1,5 @@
 import { storiesOf } from "@storybook/vue";
-import { withKnobs } from "@storybook/addon-knobs";
+import { withKnobs, boolean } from "@storybook/addon-knobs";
 
 storiesOf("Components/Molecules/Button Icon Dropdown", module)
     .addDecorator(withKnobs)
@@ -31,7 +31,9 @@ storiesOf("Components/Molecules/Button Icon Dropdown", module)
                     }
                 ]
             },
-            disabled: false
+            disabled: {
+                default: boolean("Disabled", false)
+            }
         },
         template: `
             <div>

--- a/vue/components/ui/molecules/button-icon-dropdown/button-icon-dropdown.vue
+++ b/vue/components/ui/molecules/button-icon-dropdown/button-icon-dropdown.vue
@@ -2,6 +2,8 @@
     <div class="button-icon-dropdown">
         <button-icon
             v-bind="buttonIconProps"
+            v-bind:icon-opacity="disabled ? 0.5 : 1"
+            v-bind:selectable="!disabled"
             v-bind:icon="'options'"
             v-bind:size="32"
             v-bind:active="dropdownVisible"
@@ -10,6 +12,7 @@
         />
         <dropdown
             v-bind="dropdownProps"
+            v-bind:disabled="disabled"
             v-bind:vertical-padding="4"
             v-bind:items="items"
             v-bind:visible.sync="dropdownVisible"
@@ -49,6 +52,10 @@ export const ButtonIconDropdown = {
         dropdownProps: {
             type: Object,
             default: () => ({})
+        },
+        disabled: {
+            type: Boolean,
+            default: false
         }
     },
     data: function() {
@@ -58,9 +65,11 @@ export const ButtonIconDropdown = {
     },
     methods: {
         onButtonIconClick() {
+            if (this.disabled) return;
             this.dropdownVisible = !this.dropdownVisible;
         },
         onDropdownItemClick(item, index) {
+            if (this.disabled) return;
             this.$emit(`click:item:${item.event}`, item, index);
         }
     }

--- a/vue/components/ui/molecules/button-icon-dropdown/button-icon-dropdown.vue
+++ b/vue/components/ui/molecules/button-icon-dropdown/button-icon-dropdown.vue
@@ -2,7 +2,7 @@
     <div class="button-icon-dropdown">
         <button-icon
             v-bind="buttonIconProps"
-            v-bind:icon-opacity="disabled ? 0.5 : 1"
+            v-bind:icon-opacity="disabled ? 0.4 : 1"
             v-bind:selectable="!disabled"
             v-bind:icon="'options'"
             v-bind:size="32"


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-pulse/issues/281 |
| Dependencies | -- |
| Decisions | Disable the button icon dropdown prop. |
| Animated GIF | ![button icon dropdown disable](https://user-images.githubusercontent.com/16060539/161103897-ab70e5f5-6846-4847-a99d-226ebcb5da60.gif) |

