### PR TITLE
#316 Support custom panel in `header-ripe`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* Support custom panel in `header` component - [ripe-pulse/#316](https://github.com/ripe-tech/ripe-pulse/issues/316)
 
 ### Changed
 

--- a/vue/components/ui/atoms/dropdown/dropdown.vue
+++ b/vue/components/ui/atoms/dropdown/dropdown.vue
@@ -343,7 +343,12 @@ export const Dropdown = {
             // be updated as it's missing the "event" as the first argument
             this.$emit("item-clicked", item, index);
 
+            // triggers the click item event with the proper event argument
+            // ready to be manipulated by any listener
             this.$emit("click:item", event, item, index);
+
+            // hides the dropdown as an item has been clicked, this is considered
+            // to be the default and expected behaviour
             this.hide();
         },
         highlight(index) {

--- a/vue/components/ui/atoms/dropdown/dropdown.vue
+++ b/vue/components/ui/atoms/dropdown/dropdown.vue
@@ -17,7 +17,7 @@
                     v-for="(item, index) in items.filter(v => v !== null && v !== undefined)"
                     v-else
                     v-bind:key="item.value"
-                    v-on:click="() => click(item, index)"
+                    v-on:click="event => click(event, item, index)"
                     v-on:mouseenter="() => onMouseenter(index, item)"
                     v-on:mouseleave="() => onMouseleave(index)"
                 >
@@ -328,7 +328,7 @@ export const Dropdown = {
         if (this.onHideGlobal) this.$bus.$off("hide-global", this.onHideGlobal);
     },
     methods: {
-        click(item, index) {
+        click(event, item, index) {
             if (this.managed) {
                 // invalidates all of the selected data (only one item can
                 // be selected at a time) and then updates the currently
@@ -338,7 +338,12 @@ export const Dropdown = {
                 });
                 this.$set(this.selectedData, index, true);
             }
+
+            // legacy event for backwards compatibility, this shouldn't
+            // be updated as it's missing the "event" as the first argument
             this.$emit("item-clicked", item, index);
+
+            this.$emit("click:item", event, item, index);
             this.hide();
         },
         highlight(index) {

--- a/vue/components/ui/organisms/header/header.stories.js
+++ b/vue/components/ui/organisms/header/header.stories.js
@@ -113,6 +113,10 @@ storiesOf("Components/Organisms/Header", module)
                 v-bind:search="search"
                 v-bind:logo="logo"
                 v-bind:announcements="announcements"
-            ></header-ripe>
+            >
+                <template v-slot:extra-panel-settings="{ hide }">
+                    <span v-on:click="hide">Settings panel example</span>
+                </template>
+            </header-ripe>
         </div>`
     }));

--- a/vue/components/ui/organisms/header/header.vue
+++ b/vue/components/ui/organisms/header/header.vue
@@ -460,7 +460,12 @@ export const Header = {
             const { name, email } = this.account.meta;
             items.push({ value: "name", label: name || email || this.account.email });
 
-            if (this.announcements) items.push({ value: "announcements", label: "What's new?" });
+            const announcementsItem = this.accountDropdownItems.find(
+                item => item.value === "announcements"
+            );
+            if (!announcementsItem && this.announcements) {
+                items.push({ value: "announcements", label: "What's new?" });
+            }
 
             items.push(...this.accountDropdownItems);
 
@@ -478,6 +483,7 @@ export const Header = {
                     separator: !this.settings
                 });
             }
+
             return items;
         },
         appsDropdownItems() {
@@ -527,7 +533,7 @@ export const Header = {
         onAccountDropdownItemClick(event, item, index) {
             const extraPanelName = `extra-panel-${item.value}`;
             if (
-                this.extraPanelScopedSlots.includes(extraPanelName) ||
+                this.extraPanelScopedSlots.slice("extra-panel-".length) === extraPanelName ||
                 extraPanelName === "extra-panel-announcements"
             ) {
                 this.extraPanel = extraPanelName;

--- a/vue/components/ui/organisms/header/header.vue
+++ b/vue/components/ui/organisms/header/header.vue
@@ -100,10 +100,12 @@
                         v-bind:show-links="announcements.show_links"
                         v-bind:show-reactions="announcements.show_reactions"
                         v-bind:announcements="announcements.items"
-                        v-if="announcementsModalVisible"
+                        v-if="extraPanel === 'extra-panel-announcements'"
                         v-on:click:close="hide"
                     />
-                    <slot name="extra-panel" v-bind:hide="hide" v-else />
+                    <template v-for="slot in extraPanelScopedSlots" v-else>
+                        <slot v-bind:name="slot" v-bind:hide="hide" v-if="slot === extraPanel" />
+                    </template>
                 </bubble>
                 <side
                     v-bind:visible.sync="extraPanelVisible"
@@ -120,10 +122,12 @@
                         v-bind:show-links="announcements.show_links"
                         v-bind:show-reactions="announcements.show_reactions"
                         v-bind:announcements="announcements.items"
-                        v-if="announcementsModalVisible"
+                        v-if="extraPanel === 'extra-panel-announcements'"
                         v-on:click:close="hide"
                     />
-                    <slot name="extra-panel" v-bind:hide="hide" v-else />
+                    <template v-for="slot in extraPanelScopedSlots" v-else>
+                        <slot v-bind:name="slot" v-bind:hide="hide" v-if="slot === extraPanel" />
+                    </template>
                 </side>
             </template>
         </div>
@@ -434,11 +438,14 @@ export const Header = {
             searchFilter: null,
             appsDropdownVisible: false,
             accountDropdownVisible: false,
-            announcementsModalVisible: false,
+            extraPanel: null,
             extraPanelVisible: false
         };
     },
     computed: {
+        extraPanelScopedSlots() {
+            return Object.keys(this.$scopedSlots).filter(key => key.startsWith("extra-panel-"));
+        },
         hasExtraPanel() {
             return Boolean(this.$slots["extra-panel"]) || (this.announcements && this.announcements.items);
         },
@@ -493,9 +500,7 @@ export const Header = {
             this.$emit("search-filter", value);
         },
         extraPanelVisible(value) {
-            if (!value) {
-                this.announcementsModalVisible = false;
-            }
+            if (!value) this.extraPanel = null;
         }
     },
     methods: {
@@ -512,11 +517,8 @@ export const Header = {
             this.toggleAccount();
         },
         onAccountDropdownItemClick(event, item, index) {
-            this.extraPanelVisible = item.extraPanel;
-            if (item.value === "announcements") {
-                this.announcementsModalVisible = true;
-                this.extraPanelVisible = true;
-            }
+            this.extraPanel = `extra-panel-${item.value}`;
+            this.extraPanelVisible = true;
             this.$emit("click:account-dropdown-item", event, item, index);
         },
         onAppsClick() {

--- a/vue/components/ui/organisms/header/header.vue
+++ b/vue/components/ui/organisms/header/header.vue
@@ -88,40 +88,44 @@
             </div>
         </div>
         <div class="header-globals">
-            <template v-if="announcements && announcements.items">
+            <template v-if="hasExtraPanel">
                 <bubble
-                    v-bind:visible.sync="announcementsModalVisible"
+                    v-bind:visible.sync="extraPanelVisible"
                     v-if="isMobileWidth()"
                     v-slot="{ hide }"
                 >
-                    <announcements
-                        v-bind:title="announcements.title"
-                        v-bind:description="announcements.description"
-                        v-bind:new-threshold="announcements.new_threshold"
-                        v-bind:show-subscribe="announcements.show_subscribe"
-                        v-bind:show-links="announcements.show_links"
-                        v-bind:show-reactions="announcements.show_reactions"
-                        v-bind:announcements="announcements.items"
-                        v-on:click:close="hide"
-                    />
+                    <slot name="extra-panel">
+                        <announcements
+                            v-bind:title="announcements.title"
+                            v-bind:description="announcements.description"
+                            v-bind:new-threshold="announcements.new_threshold"
+                            v-bind:show-subscribe="announcements.show_subscribe"
+                            v-bind:show-links="announcements.show_links"
+                            v-bind:show-reactions="announcements.show_reactions"
+                            v-bind:announcements="announcements.items"
+                            v-on:click:close="hide"
+                        />
+                    </slot>
                 </bubble>
                 <side
-                    v-bind:visible.sync="announcementsModalVisible"
+                    v-bind:visible.sync="extraPanelVisible"
                     v-bind:width="370"
                     v-bind:position="'right'"
                     v-else
                     v-slot="{ hide }"
                 >
-                    <announcements
-                        v-bind:title="announcements.title"
-                        v-bind:description="announcements.description"
-                        v-bind:new-threshold="announcements.new_threshold"
-                        v-bind:show-subscribe="announcements.show_subscribe"
-                        v-bind:show-links="announcements.show_links"
-                        v-bind:show-reactions="announcements.show_reactions"
-                        v-bind:announcements="announcements.items"
-                        v-on:click:close="hide"
-                    />
+                    <slot name="extra-panel">
+                        <announcements
+                            v-bind:title="announcements.title"
+                            v-bind:description="announcements.description"
+                            v-bind:new-threshold="announcements.new_threshold"
+                            v-bind:show-subscribe="announcements.show_subscribe"
+                            v-bind:show-links="announcements.show_links"
+                            v-bind:show-reactions="announcements.show_reactions"
+                            v-bind:announcements="announcements.items"
+                            v-on:click:close="hide"
+                        />
+                    </slot>
                 </side>
             </template>
         </div>
@@ -436,6 +440,12 @@ export const Header = {
         };
     },
     computed: {
+        hasExtraPanel() {
+            return Boolean(this.$slots["extra-panel"]) || (this.announcements && this.announcements.items);
+        },
+        extraPanelVisible() {
+            return this.announcementsModalVisible;
+        },
         account() {
             return this.platformeAccount || this.$root.account;
         },

--- a/vue/components/ui/organisms/header/header.vue
+++ b/vue/components/ui/organisms/header/header.vue
@@ -386,7 +386,7 @@ export const Header = {
         },
         accountDropdownItems: {
             type: Array,
-            default: []
+            default: () => []
         },
         settings: {
             type: Boolean,

--- a/vue/components/ui/organisms/header/header.vue
+++ b/vue/components/ui/organisms/header/header.vue
@@ -525,8 +525,11 @@ export const Header = {
             this.toggleAccount();
         },
         onAccountDropdownItemClick(event, item, index) {
-            this.extraPanel = `extra-panel-${item.value}`;
-            this.extraPanelVisible = true;
+            const extraPanelName = `extra-panel-${item.value}`;
+            if (this.extraPanelScopedSlots.includes(extraPanelName) || extraPanelName === "extra-panel-announcements") {
+                this.extraPanel = extraPanelName;
+                this.extraPanelVisible = true;
+            }
             this.$emit("click:account-dropdown-item", event, item, index);
         },
         onAppsClick() {

--- a/vue/components/ui/organisms/header/header.vue
+++ b/vue/components/ui/organisms/header/header.vue
@@ -526,7 +526,10 @@ export const Header = {
         },
         onAccountDropdownItemClick(event, item, index) {
             const extraPanelName = `extra-panel-${item.value}`;
-            if (this.extraPanelScopedSlots.includes(extraPanelName) || extraPanelName === "extra-panel-announcements") {
+            if (
+                this.extraPanelScopedSlots.includes(extraPanelName) ||
+                extraPanelName === "extra-panel-announcements"
+            ) {
                 this.extraPanel = extraPanelName;
                 this.extraPanelVisible = true;
             }

--- a/vue/components/ui/organisms/header/header.vue
+++ b/vue/components/ui/organisms/header/header.vue
@@ -378,6 +378,10 @@ export const Header = {
             type: Boolean,
             default: true
         },
+        developer: {
+            type: Boolean,
+            default: true
+        },
         settings: {
             type: Boolean,
             default: true
@@ -440,11 +444,18 @@ export const Header = {
             const { name, email } = this.account.meta;
             items.push({ value: "name", label: name || email || this.account.email });
             if (this.announcements) items.push({ value: "announcements", label: "What's new?" });
+            if (this.developer) {
+                items.push({
+                    value: "developer",
+                    label: "Developer techincal ",
+                    separator: true
+                });
+            }
             if (this.settings) {
                 items.push({
                     value: "settings",
                     label: "Account settings",
-                    separator: true
+                    separator: !this.developer
                 });
             }
             if (this.signout) {

--- a/vue/components/ui/organisms/header/header.vue
+++ b/vue/components/ui/organisms/header/header.vue
@@ -448,7 +448,7 @@ export const Header = {
         },
         hasExtraPanel() {
             return (
-                Boolean(this.$slots["extra-panel"]) ||
+                this.extraPanelScopedSlots.length > 0 ||
                 (this.announcements && this.announcements.items)
             );
         },

--- a/vue/components/ui/organisms/header/header.vue
+++ b/vue/components/ui/organisms/header/header.vue
@@ -436,15 +436,12 @@ export const Header = {
             searchFilter: null,
             appsDropdownVisible: false,
             accountDropdownVisible: false,
-            announcementsModalVisible: false
+            extraPanelVisible: false
         };
     },
     computed: {
         hasExtraPanel() {
             return Boolean(this.$slots["extra-panel"]) || (this.announcements && this.announcements.items);
-        },
-        extraPanelVisible() {
-            return this.announcementsModalVisible;
         },
         account() {
             return this.platformeAccount || this.$root.account;
@@ -517,7 +514,7 @@ export const Header = {
             this.appsDropdownVisible = !this.appsDropdownVisible;
         },
         showAnnouncements() {
-            this.announcementsModalVisible = true;
+            this.extraPanelVisible = true;
         },
         onAccountClick() {
             this.toggleAccount();

--- a/vue/components/ui/organisms/header/header.vue
+++ b/vue/components/ui/organisms/header/header.vue
@@ -447,7 +447,10 @@ export const Header = {
             return Object.keys(this.$scopedSlots).filter(key => key.startsWith("extra-panel-"));
         },
         hasExtraPanel() {
-            return Boolean(this.$slots["extra-panel"]) || (this.announcements && this.announcements.items);
+            return (
+                Boolean(this.$slots["extra-panel"]) ||
+                (this.announcements && this.announcements.items)
+            );
         },
         account() {
             return this.platformeAccount || this.$root.account;
@@ -468,7 +471,12 @@ export const Header = {
 
             const signoutItem = this.accountDropdownItems.find(item => item.value === "signout");
             if (!signoutItem && this.signout) {
-                items.push({ value: "signout", label: "Sign out", link: "/signout", separator: !this.settings });
+                items.push({
+                    value: "signout",
+                    label: "Sign out",
+                    link: "/signout",
+                    separator: !this.settings
+                });
             }
             return items;
         },


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-pulse/issues/316 |
| Dependencies | -- |
| Decisions | • Add proper `dropdown` click event that supports `event` parameter (maitaining backwards compatibility)<br>• Support customization of the account dropdown list in the `header-ripe` component<br>• Support custom panel in the `header-ripe` component |

https://user-images.githubusercontent.com/22588915/161925503-89e5c0ef-e201-4fd2-abd3-e3a482741cb1.mov

https://user-images.githubusercontent.com/22588915/161925494-f08e3e51-4966-45d1-ba90-d23f1a4edd63.mov