### PR TITLE
#316 Fix `header-ripe` by reverting some refactor changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-*
+* Revert `header` refactor change related to `extra-panel` - [ripe-pulse/#316](https://github.com/ripe-tech/ripe-pulse/issues/316)
 
 ## [0.21.0] - 2022-04-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-* Revert `header` refactor change related to `extra-panel` - [ripe-pulse/#316](https://github.com/ripe-tech/ripe-pulse/issues/316)
+* Revert `header-ripe` refactor change related to `extra-panel` - [ripe-pulse/#316](https://github.com/ripe-tech/ripe-pulse/issues/316)
 
 ## [0.21.0] - 2022-04-04
 

--- a/vue/components/ui/organisms/header/header.vue
+++ b/vue/components/ui/organisms/header/header.vue
@@ -533,7 +533,7 @@ export const Header = {
         onAccountDropdownItemClick(event, item, index) {
             const extraPanelName = `extra-panel-${item.value}`;
             if (
-                this.extraPanelScopedSlots.slice("extra-panel-".length) === extraPanelName ||
+                this.extraPanelScopedSlots.includes(extraPanelName) ||
                 extraPanelName === "extra-panel-announcements"
             ) {
                 this.extraPanel = extraPanelName;


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-pulse/issues/316 (related: to https://github.com/ripe-tech/ripe-components-vue/pull/573) |
| Dependencies | -- |
| Decisions | Revert refactor breaking changes. `extraPanelScopedSlots` is not a string, it's an array already filtering the slots for the panel |
