### PR TITLE
#580 Closing the file browser dialog removes the previous selected file in upload components #580

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Revert `header-ripe` refactor change related to `extra-panel` - [ripe-pulse/#316](https://github.com/ripe-tech/ripe-pulse/issues/316)
+* Fix upload mixin removing previous file when closing file browser dialog without selecting a file - [#580](https://github.com/ripe-tech/ripe-components-vue/issues/580)
 
 ## [0.21.0] - 2022-04-04
 

--- a/vue/mixins/upload.js
+++ b/vue/mixins/upload.js
@@ -61,6 +61,7 @@ export const uploadMixin = {
             this.dragging = false;
         },
         onFilesInputChange() {
+            if (this.fileInputRef.files.length === 0) return;
             this.setFiles(this.fileInputRef.files);
         },
         onUploadButtonClick() {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-components-vue/issues/580 |
| Decisions | If `FileList` is empty do not set internal value |
| Animated GIF | ![UmMGJ3YGAg](https://user-images.githubusercontent.com/8842023/163137218-e951fee7-2b18-4988-b528-77f62662edf3.gif) |
