### PR TITLE
#270 Support webpack@4 `raw-loader` logic for icons provided by external sources 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Revert `header-ripe` refactor change related to `extra-panel` - [ripe-pulse/#316](https://github.com/ripe-tech/ripe-pulse/issues/316)
 * Fix upload mixin removing previous file when closing file browser dialog without selecting a file - [#580](https://github.com/ripe-tech/ripe-components-vue/issues/580)
+* Support webpack@4 `raw-loader` logic for icons provided by external sources (from the project using this as a library)
 
 ## [0.21.0] - 2022-04-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Revert `header-ripe` refactor change related to `extra-panel` - [ripe-pulse/#316](https://github.com/ripe-tech/ripe-pulse/issues/316)
 * Fix upload mixin removing previous file when closing file browser dialog without selecting a file - [#580](https://github.com/ripe-tech/ripe-components-vue/issues/580)
-* Support webpack@4 `raw-loader` logic for icons provided by external sources (from the project using this as a library)
+* Support webpack@4 `raw-loader` logic for icons provided by external sources (from the project using this as a library) - [ripe-util-vue/#270](https://github.com/ripe-tech/ripe-util-vue/issues/270)
 
 ## [0.21.0] - 2022-04-04
 

--- a/vue/components/ui/atoms/icon/icon.vue
+++ b/vue/components/ui/atoms/icon/icon.vue
@@ -97,7 +97,7 @@ export const Icon = {
                     // if there is a custom context defined at the root that
                     // contains the item, then uses it
                     if (iconContext) {
-                        resource = this.loadFromContext(iconContext, this.icon);
+                        resource = this.loadIconContext(iconContext, this.icon);
                     }
                     // otherwise fallback to default strategy for the retrieval
                     // of icons, using the `try` and `catch` strategy
@@ -141,15 +141,16 @@ export const Icon = {
                 attrs.forEach(attr => this.setSvgAttribute(attr.key, attr.value));
             });
         },
-        loadFromContext(context, icon) {
-            // supports both webpack 5 and webpack 4 assets bundling logic
+        loadIconContext(context, icon, suffix = "svg") {
             try {
-                return context(`./${icon}.svg?raw`);
+                // tries to use the new webpack 5 strategy for the loading
+                // of the icon using the context strategy
+                return context(`./${icon}.${suffix}?raw`);
             } catch {
                 // defaults to webpack 4 asset bundling logic if v5
                 // retrieval resulted in an error, making it possible
                 // to use external assets loaded by raw-loader
-                return context(`./${icon}.svg`).default;
+                return context(`./${icon}.${suffix}`).default;
             }
         }
     },

--- a/vue/components/ui/atoms/icon/icon.vue
+++ b/vue/components/ui/atoms/icon/icon.vue
@@ -97,7 +97,7 @@ export const Icon = {
                     // if there is a custom context defined at the root that
                     // contains the item, then uses it
                     if (iconContext) {
-                        resource = iconContext(`./${this.icon}.svg?raw`);
+                        resource = this.loadFromContext(iconContext, this.icon);
                     }
                     // otherwise fallback to default strategy for the retrieval
                     // of icons, using the `try` and `catch` strategy
@@ -140,6 +140,17 @@ export const Icon = {
             this.$nextTick(() => {
                 attrs.forEach(attr => this.setSvgAttribute(attr.key, attr.value));
             });
+        },
+        loadFromContext(context, icon) {
+            // supports both webpack 5 and webpack 4 assets bundling logic
+            try {
+                return context(`./${icon}.svg?raw`);
+            } catch {
+                // defaults to webpack 4 asset bundling logic if v5
+                // retrieval resulted in an error, making it possible
+                // to use external assets loaded by raw-loader
+                return context(`./${icon}.svg`).default;
+            }
         }
     },
     mounted: function() {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Problem found by @NFSS10: In util-vue, the icons provided by that repo but accessible by `require.context` were not being shown <br>![image](https://user-images.githubusercontent.com/25725586/164275965-476c9461-3dd1-4841-8076-5e576c6bb3d5.png)<br>(related https://github.com/ripe-tech/ripe-util-vue/issues/270) |
| Dependencies | -- |
| Decisions | - In icon loading, support both the logic of webpack5 (the `raw` query param that allow using the `asset/source` loader from webpack@5) and the previous logic (without `raw` and uses `raw-loader`, that requires the decomposition of the returned object with `.default`). **This is a problem because `ripe-util-vue` uses webpack 4 because Nuxt@2 does not support webpack 5** |
| Animated GIF | ![image](https://user-images.githubusercontent.com/25725586/164275742-4c17eae7-b2c6-4d11-98b3-651260c8f521.png)|
