### PR TITLE
#270 `iconPosition` prop for `button-color`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add `entry` component - [ripe-pulse/#316](https://github.com/ripe-tech/ripe-pulse/issues/316)
 * Background color for checked rows in table component - [ripe-pulse/#281](https://github.com/ripe-tech/ripe-pulse/issues/281)
 * Add prop `rowSelection` to listing and filter components and pass it to table - [ripe-pulse/#281](https://github.com/ripe-tech/ripe-pulse/issues/281)
-* Support search bar in `select-checkboxes`[ripe-util-vue/#270](https://github.com/ripe-tech/ripe-util-vue/issues/270)
-* Add prop `highlightable` to allow to turn off ability to highlight `dropdown` items[ripe-util-vue/#270](https://github.com/ripe-tech/ripe-util-vue/issues/270)
+* Support search bar in `select-checkboxes` - [ripe-util-vue/#270](https://github.com/ripe-tech/ripe-util-vue/issues/270)
+* Add prop `highlightable` to allow to turn off ability to highlight `dropdown` items - [ripe-util-vue/#270](https://github.com/ripe-tech/ripe-util-vue/issues/270)
+* Add prop `iconPosition` to `button-color` allowing to change the icon position - [ripe-util-vue/#270](https://github.com/ripe-tech/ripe-util-vue/issues/270)
 
 ### Changed
 

--- a/vue/components/ui/atoms/button-color/button-color.stories.js
+++ b/vue/components/ui/atoms/button-color/button-color.stories.js
@@ -62,6 +62,16 @@ storiesOf("Components/Atoms/Button Color", module)
                     "add"
                 )
             },
+            iconPosition: {
+                default: select(
+                    "Icon Position",
+                    {
+                        Left: "left",
+                        Right: "right"
+                    },
+                    "left"
+                )
+            },
             disabled: {
                 default: boolean("Disabled", false)
             },
@@ -79,9 +89,10 @@ storiesOf("Components/Atoms/Button Color", module)
                 <button-color v-bind:text="'Small Button'" v-bind:secondary="secondary" v-bind:size="size" v-bind:color="color" v-bind:alignment="alignment"
                     v-bind:disabled="disabled" v-bind:loading="loading" v-bind:small="true" v-bind:min-width="minWidth" ></button-color>
                 <button-color v-bind:text="'Normal Button'" v-bind:secondary="secondary" v-bind:size="size" v-bind:color="color" v-bind:alignment="alignment"
-                    v-bind:disabled="disabled" v-bind:loading="loading" v-bind:icon="icon" v-bind:min-width="minWidth" ></button-color>
+                    v-bind:disabled="disabled" v-bind:loading="loading" v-bind:icon="icon" v-bind:icon-position="iconPosition" v-bind:min-width="minWidth"></button-color>
                 <button-color v-bind:text="'Small Button'" v-bind:secondary="secondary" v-bind:size="size" v-bind:color="color" v-bind:alignment="alignment"
-                    v-bind:disabled="disabled" v-bind:loading="loading" v-bind:small="true" v-bind:icon="icon" v-bind:min-width="minWidth" ></button-color>
+                    v-bind:disabled="disabled" v-bind:loading="loading" v-bind:small="true" v-bind:icon="icon" v-bind:icon-position="iconPosition"
+                    v-bind:min-width="minWidth"></button-color>
             </div>
         `
     }));

--- a/vue/components/ui/atoms/button-color/button-color.vue
+++ b/vue/components/ui/atoms/button-color/button-color.vue
@@ -6,6 +6,9 @@
         v-bind:type="type"
         v-on:click="handleClick"
     >
+        <span v-show="!loading" v-if="iconPosition === 'right'">
+            <slot>{{ text }}</slot>
+        </span>
         <loader
             loader="ball-scale-multiple"
             class="loader"
@@ -28,7 +31,7 @@
             v-bind:height="iconSize"
             v-if="icon && !loading"
         />
-        <span v-show="!loading">
+        <span v-show="!loading" v-if="iconPosition === 'left'">
             <slot>{{ text }}</slot>
         </span>
     </button>
@@ -255,11 +258,21 @@
 
 .button-color .icon,
 .button-color .icon-hover {
-    float: left;
     height: 22px;
     margin-top: 8px;
-    padding-right: 12px;
     width: 22px;
+}
+
+.button-color.icon-position-left .icon,
+.button-color.icon-position-left .icon-hover {
+    float: left;
+    padding-right: 12px;
+}
+
+.button-color.icon-position-right .icon,
+.button-color.icon-position-right .icon-hover {
+    float: right;
+    padding-left: 12px;
 }
 
 .button-color.button-color-small .icon,
@@ -350,6 +363,10 @@ export const ButtonColor = {
             type: String,
             default: null
         },
+        iconPosition: {
+            type: String,
+            default: "left"
+        },
         href: {
             type: String,
             default: null
@@ -417,6 +434,7 @@ export const ButtonColor = {
             };
 
             base["button-color-" + this.sizeMode] = true;
+            base["icon-position-" + this.iconPosition] = true;
 
             if (this.color) {
                 base["button-color-" + this.color] = this.color;

--- a/vue/components/ui/atoms/button-color/button-color.vue
+++ b/vue/components/ui/atoms/button-color/button-color.vue
@@ -263,18 +263,6 @@
     width: 22px;
 }
 
-.button-color.icon-position-left .icon,
-.button-color.icon-position-left .icon-hover {
-    float: left;
-    padding-right: 12px;
-}
-
-.button-color.icon-position-right .icon,
-.button-color.icon-position-right .icon-hover {
-    float: right;
-    padding-left: 12px;
-}
-
 .button-color.button-color-small .icon,
 .button-color.button-color-small .icon-hover {
     height: 18px;
@@ -308,6 +296,18 @@
 
 .button-color:hover .icon-hover {
     display: inline-block;
+}
+
+.button-color.icon-position-left .icon,
+.button-color.icon-position-left .icon-hover {
+    float: left;
+    padding-right: 12px;
+}
+
+.button-color.icon-position-right .icon,
+.button-color.icon-position-right .icon-hover {
+    margin-top: 0px;
+    padding-left: 12px;
 }
 </style>
 


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-util-vue/issues/270 |
| Dependencies | -- |
| Decisions | Add prop `iconPosition` to `button-color` allowing to change the icon position |

https://user-images.githubusercontent.com/22588915/164482715-e33019be-ec82-449a-82c0-c6a6e74203d8.mp4
