### PR TITLE
#275 remove `router-link` from home color part component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* `router-link` removed from `home-color-part` component for it to be compatible with nuxt projects too [ripe-components-vue/#275](https://github.com/ripe-tech/ripe-util-vue/issues/275)
+* `router-link` removed from `home-color-part` component for it to be compatible with nuxt projects too - [ripe-util-vue/#275](https://github.com/ripe-tech/ripe-util-vue/issues/275)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Prop issue in `button-icon-dropdown` when propagating `disabled`
+* `target` prop for `link-ripe` component used in `home-color-part` component
 
 ## [0.22.0] - 2022-04-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* `router-link` removed from `home-color-part` component for it to be compatible with nuxt projects too
+* `router-link` removed from `home-color-part` component for it to be compatible with nuxt projects too [ripe-components-vue/#275](https://github.com/ripe-tech/ripe-util-vue/issues/275)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-*
+* `router-link` removed from `home-color-part` component for it to be compatible with nuxt projects too
 
 ### Fixed
 

--- a/vue/components/ui/templates/home-color-part/home-color-part.vue
+++ b/vue/components/ui/templates/home-color-part/home-color-part.vue
@@ -212,10 +212,6 @@ export const HomeColorPart = {
             type: String | Object,
             default: null
         },
-        homeRoute: {
-            type: String | Object,
-            default: null
-        },
         nextRoute: {
             type: String | Object,
             default: null

--- a/vue/components/ui/templates/home-color-part/home-color-part.vue
+++ b/vue/components/ui/templates/home-color-part/home-color-part.vue
@@ -1,9 +1,9 @@
 <template>
     <div class="home-color-part" v-bind:class="classes" v-bind:style="style" v-if="visible">
         <div class="top">
-            <router-link class="logo-container" v-bind:to="homeRoute">
+            <div class="logo-container" v-on:click="onLogoClick">
                 <image-ripe class="logo" v-bind:src="logo" />
-            </router-link>
+            </div>
             <div class="links">
                 <router-link
                     class="link"
@@ -78,6 +78,7 @@ body.mobile .home-color-part > .top {
 }
 
 .home-color-part > .top > .logo-container {
+    cursor: pointer;
     display: block;
     height: 60px;
 }
@@ -288,6 +289,9 @@ export const HomeColorPart = {
             } catch (err) {
                 this.handleError(err);
             }
+        },
+        onLogoClick() {
+            this.$emit("click:logo");
         },
         _linksColor(color) {
             switch (color) {

--- a/vue/components/ui/templates/home-color-part/home-color-part.vue
+++ b/vue/components/ui/templates/home-color-part/home-color-part.vue
@@ -42,7 +42,7 @@
                     v-bind:color="linksBottomColor"
                     v-bind:hover="'border'"
                     v-bind:href="'https://www.platforme.com'"
-                    v-bind:target="_blank"
+                    v-bind:target="'_blank'"
                 />
             </div>
             <div class="copyright">


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | originated while doing https://github.com/ripe-tech/ripe-util-vue/issues/275 |
| Decisions | - remove `router-link` and use a div that emits a `logo:click` event on click |
| Animation gif | ![eKsuR4dRsK](https://user-images.githubusercontent.com/8842023/166426054-e9366175-8168-4287-bb29-2fefdd148b5d.gif)|
