### PR TITLE
Input: `debounceTime` prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Added variant "white" to `input-image`
 * Added prop `textColor` to `tag` component to allow customizing the text color - [#296](https://github.com/ripe-tech/ripe-pulse/issues/296)
+* Added prop `debounceTime` to component `input-ripe` allowing a delay between the input events and the actual `setValue`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,7 +101,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Added variant "white" to `input-image`
 * Added prop `textColor` to `tag` component to allow customizing the text color - [#296](https://github.com/ripe-tech/ripe-pulse/issues/296)
-* Added prop `debounceTime` to component `input-ripe` allowing a delay between the input events and the actual `setValue`
+* Added prop `debounceDelay` to component `input-ripe` allowing a delay between the input events and the actual `setValue`
 
 ### Fixed
 

--- a/vue/components/ui/atoms/input/input.stories.js
+++ b/vue/components/ui/atoms/input/input.stories.js
@@ -69,6 +69,9 @@ storiesOf("Components/Atoms/Input", module)
             },
             maxLength: {
                 default: number("Max Length", null)
+            },
+            debounceTime: {
+                default: number("Debounce Time", 0)
             }
         },
         data: function() {
@@ -98,7 +101,8 @@ storiesOf("Components/Atoms/Input", module)
                         v-bind:width="width"
                         v-bind:min-width="minWidth"
                         v-bind:height="height"
-                        v-bind:maxLength="maxLength" />
+                        v-bind:debounce-time="debounceTime"
+                        v-bind:max-length="maxLength" />
                 </form-input>
                 <p>Text: {{ valueData }}</p>
             </div>

--- a/vue/components/ui/atoms/input/input.stories.js
+++ b/vue/components/ui/atoms/input/input.stories.js
@@ -67,11 +67,11 @@ storiesOf("Components/Atoms/Input", module)
             height: {
                 default: number("Height", null)
             },
+            debounceDelay: {
+                default: number("Debounce Delay", 0)
+            },
             maxLength: {
                 default: number("Max Length", null)
-            },
-            debounceTime: {
-                default: number("Debounce Time", 0)
             }
         },
         data: function() {
@@ -101,7 +101,7 @@ storiesOf("Components/Atoms/Input", module)
                         v-bind:width="width"
                         v-bind:min-width="minWidth"
                         v-bind:height="height"
-                        v-bind:debounce-time="debounceTime"
+                        v-bind:debounce-delay="debounceDelay"
                         v-bind:max-length="maxLength" />
                 </form-input>
                 <p>Text: {{ valueData }}</p>

--- a/vue/components/ui/atoms/input/input.vue
+++ b/vue/components/ui/atoms/input/input.vue
@@ -151,9 +151,9 @@ export const Input = {
             type: String,
             default: null
         },
-        debounceTime: {
+        debounceDelay: {
             type: Number,
-            default: 0
+            default: null
         },
         maxLength: {
             type: Number,
@@ -164,19 +164,24 @@ export const Input = {
         if (this.autofocus) this.focus();
         this.setValidationMessage(this.validationMessage);
     },
+    data: function() {
+        return {
+            debounceTimeout: null
+        };
+    },
     methods: {
         setValue(value) {
-            if (this.debounceTime) {
+            if (this.debounceDelay) {
                 this.setValueDebounced(value);
             } else {
                 this.$emit("update:value", value);
             }
         },
-        setValueDebounced(value, time = this.debounceTime) {
+        setValueDebounced(value, delay = this.debounceDelay) {
             if (this.debounceTimeout) clearTimeout(this.debounceTimeout);
             this.debounceTimeout = setTimeout(() => {
                 this.$emit("update:value", value);
-            }, time);
+            }, delay);
         },
         focus() {
             this.$refs.input.focus();

--- a/vue/components/ui/atoms/input/input.vue
+++ b/vue/components/ui/atoms/input/input.vue
@@ -173,11 +173,11 @@ export const Input = {
             }
         },
         setValueDebounced(value, time = this.debounceTime) {
-            if(this.debounceTimeout) clearTimeout(this.debounceTimeout);
+            if (this.debounceTimeout) clearTimeout(this.debounceTimeout);
 
             this.debounceTimeout = setTimeout(() => {
                 this.$emit("update:value", value);
-            }, time)
+            }, time);
         },
         focus() {
             this.$refs.input.focus();

--- a/vue/components/ui/atoms/input/input.vue
+++ b/vue/components/ui/atoms/input/input.vue
@@ -174,7 +174,6 @@ export const Input = {
         },
         setValueDebounced(value, time = this.debounceTime) {
             if (this.debounceTimeout) clearTimeout(this.debounceTimeout);
-
             this.debounceTimeout = setTimeout(() => {
                 this.$emit("update:value", value);
             }, time);

--- a/vue/components/ui/atoms/input/input.vue
+++ b/vue/components/ui/atoms/input/input.vue
@@ -151,6 +151,10 @@ export const Input = {
             type: String,
             default: null
         },
+        debounceTime: {
+            type: Number,
+            default: 0
+        },
         maxLength: {
             type: Number,
             default: null
@@ -162,7 +166,18 @@ export const Input = {
     },
     methods: {
         setValue(value) {
-            this.$emit("update:value", value);
+            if (this.debounceTime) {
+                this.setValueDebounced(value);
+            } else {
+                this.$emit("update:value", value);
+            }
+        },
+        setValueDebounced(value, time = this.debounceTime) {
+            if(this.debounceTimeout) clearTimeout(this.debounceTimeout);
+
+            this.debounceTimeout = setTimeout(() => {
+                this.$emit("update:value", value);
+            }, time)
         },
         focus() {
             this.$refs.input.focus();


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Suggestion by @joamag  |
| Decisions | - Added prop `debounceTime` to component `input-ripe` allowing a delay between the input events and the actual `setValue`  |
| Animated GIF | Below |


https://user-images.githubusercontent.com/24736423/166245651-2510d534-9107-4063-9ca0-23df0ebff3a9.mov

