### PR TITLE
feat: global hide prop in button icon dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Add `input-file` component - [ripe-copper/#48](https://github.com/ripe-tech/ripe-copper/issues/48)
+* Button icon dropdown component click events - [ripe-pulse/#281](https://github.com/ripe-tech/ripe-pulse/issues/281)
+* Button icon dropdown open/close methods - [ripe-pulse/#281](https://github.com/ripe-tech/ripe-pulse/issues/281)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Add `input-file` component - [ripe-copper/#48](https://github.com/ripe-tech/ripe-copper/issues/48)
-* Button icon dropdown component click events - [ripe-pulse/#281](https://github.com/ripe-tech/ripe-pulse/issues/281)
-* Button icon dropdown open/close methods - [ripe-pulse/#281](https://github.com/ripe-tech/ripe-pulse/issues/281)
+* Button icon dropdown global hide prop - [ripe-pulse/#281](https://github.com/ripe-tech/ripe-pulse/issues/281)
 
 ### Changed
 

--- a/vue/components/ui/atoms/dropdown/dropdown.vue
+++ b/vue/components/ui/atoms/dropdown/dropdown.vue
@@ -408,7 +408,8 @@ export const Dropdown = {
                 separator: item.separator,
                 icon: Boolean(item.icon),
                 highlightable: this.highlightable,
-                highlighted: this.highlightable && (this.highlightedData[index] || item.highlighted),
+                highlighted:
+                    this.highlightable && (this.highlightedData[index] || item.highlighted),
                 selected: this.highlightable && (this.selectedData[index] || item.selected),
                 disabled: this.disabledData[index] || item.disabled
             };

--- a/vue/components/ui/molecules/button-icon-dropdown/button-icon-dropdown.vue
+++ b/vue/components/ui/molecules/button-icon-dropdown/button-icon-dropdown.vue
@@ -15,6 +15,7 @@
             v-bind:vertical-padding="4"
             v-bind:items="items"
             v-bind:visible.sync="dropdownVisible"
+            v-bind:global-hide="globalHide"
             v-bind:owners="$refs['button-icon']"
             v-on:item-clicked="onDropdownItemClick"
         >
@@ -53,6 +54,10 @@ export const ButtonIconDropdown = {
             default: () => ({})
         },
         disabled: {
+            type: Boolean,
+            default: false
+        },
+        globalHide: {
             type: Boolean,
             default: false
         }

--- a/vue/components/ui/molecules/button-icon-dropdown/button-icon-dropdown.vue
+++ b/vue/components/ui/molecules/button-icon-dropdown/button-icon-dropdown.vue
@@ -68,16 +68,9 @@ export const ButtonIconDropdown = {
         };
     },
     methods: {
-        open() {
-            this.dropdownVisible = true;
-        },
-        close() {
-            this.dropdownVisible = false;
-        },
         onButtonIconClick() {
             if (this.disabled) return;
             this.dropdownVisible = !this.dropdownVisible;
-            this.$emit(`click:${this.dropdownVisible ? "open" : "close"}`, this);
         },
         onDropdownItemClick(item, index) {
             if (this.disabled) return;

--- a/vue/components/ui/molecules/button-icon-dropdown/button-icon-dropdown.vue
+++ b/vue/components/ui/molecules/button-icon-dropdown/button-icon-dropdown.vue
@@ -63,9 +63,16 @@ export const ButtonIconDropdown = {
         };
     },
     methods: {
+        open() {
+            this.dropdownVisible = true;
+        },
+        close() {
+            this.dropdownVisible = false;
+        },
         onButtonIconClick() {
             if (this.disabled) return;
             this.dropdownVisible = !this.dropdownVisible;
+            this.$emit(`click:${this.dropdownVisible ? "open" : "close"}`, this);
         },
         onDropdownItemClick(item, index) {
             if (this.disabled) return;


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-pulse/issues/281 https://github.com/ripe-tech/ripe-pulse/issues/281#issuecomment-1084775305 |
| Dependencies | -- |
| Decisions | Emit proper events for open/closing of the dropdown and have open/close methods for abstraction purposes. |
| Animated GIF | ![281-open-close-dropdown](https://user-images.githubusercontent.com/16060539/166692378-ef1ce405-1f45-4b39-94d2-288d684e285e.gif) |
