### PR TITLE
Support node `16` , `17` and `18`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ jobs:
     name: Build
     strategy:
       matrix:
-        node-version: [12, 13, 14, 16]
+        node-version: [12, 13, 14, 16, 17, 18]
     runs-on: ubuntu-latest
     container: node:${{ matrix.node-version }}
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ jobs:
     name: Build
     strategy:
       matrix:
-        node-version: [12, 13, 14]
+        node-version: [12, 13, 14, 16]
     runs-on: ubuntu-latest
     container: node:${{ matrix.node-version }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add slots to `input-symbol` component - [ripe-util-vue/#259](https://github.com/ripe-tech/ripe-util-vue/issues/259)
 * Button icon dropdown global hide prop - [ripe-pulse/#281](https://github.com/ripe-tech/ripe-pulse/issues/281)
 * Add `avatar-list` component - [#571](https://github.com/ripe-tech/ripe-components-vue/issues/571)
+* Add node `16` support
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add slots to `input-symbol` component - [ripe-util-vue/#259](https://github.com/ripe-tech/ripe-util-vue/issues/259)
 * Button icon dropdown global hide prop - [ripe-pulse/#281](https://github.com/ripe-tech/ripe-pulse/issues/281)
 * Add `avatar-list` component - [#571](https://github.com/ripe-tech/ripe-components-vue/issues/571)
-* Add node `16` support
+* Add node `16`, `17` and `18` support
 
 ### Changed
 


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Node `16` is LTS and currently CI/CD isn't running for that version. `ripe-components-vue` is a very active project, thus this project should have an active maintenance (relevant: https://github.com/ripe-tech/ripe-welcome/pull/187#issue-1241883511) |
| Dependencies | -- |
| Decisions | Added node `16`, `17` and `18` to github CI/CD |

Reference: https://nodejs.org/en/about/releases/

**NOTE:** Github jobs are failling because of the known storybook issue https://github.com/ripe-tech/ripe-welcome/pull/187#issue-1241883511