### PR TITLE
#288 button-dropdown disabled prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Button icon dropdown global hide prop - [ripe-pulse/#281](https://github.com/ripe-tech/ripe-pulse/issues/281)
 * Add `avatar-list` component - [#571](https://github.com/ripe-tech/ripe-components-vue/issues/571)
 * Add node `16`, `17` and `18` support
-* Add `disabled` prop to `button-dropdown` - [ripe-util-vue/#1002](https://github.com/ripe-tech/ripe-white/issues/1002)
+* Add `disabled` prop to `button-dropdown` - [ripe-util-vue/#288](https://github.com/ripe-tech/ripe-util-vue/issues/288)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Button icon dropdown global hide prop - [ripe-pulse/#281](https://github.com/ripe-tech/ripe-pulse/issues/281)
 * Add `avatar-list` component - [#571](https://github.com/ripe-tech/ripe-components-vue/issues/571)
 * Add node `16`, `17` and `18` support
+* Add `disabled` prop to `button-dropdown` - [ripe-util-vue/#1002](https://github.com/ripe-tech/ripe-white/issues/1002)
 
 ### Changed
 

--- a/vue/components/ui/molecules/button-dropdown/button-dropdown.stories.js
+++ b/vue/components/ui/molecules/button-dropdown/button-dropdown.stories.js
@@ -1,5 +1,5 @@
 import { storiesOf } from "@storybook/vue";
-import { withKnobs, select, text } from "@storybook/addon-knobs";
+import { withKnobs, select, text, boolean } from "@storybook/addon-knobs";
 
 storiesOf("Components/Molecules/Button Dropdown", module)
     .addDecorator(withKnobs)
@@ -41,6 +41,10 @@ storiesOf("Components/Molecules/Button Dropdown", module)
             label: {
                 default: text("Label", "Edit dropdown")
             },
+            disabled: {
+                type: Boolean,
+                default: boolean("Disabled", false)
+            },
             mockItems: {
                 type: Array,
                 default: () => [
@@ -53,6 +57,7 @@ storiesOf("Components/Molecules/Button Dropdown", module)
             <button-dropdown
                 v-bind:size="size"
                 v-bind:label="label"
+                v-bind:disabled="disabled"
                 v-bind:primary-icon="primaryIcon"
                 v-bind:secondary-icon="secondaryIcon"
                 v-bind:items="mockItems"

--- a/vue/components/ui/molecules/button-dropdown/button-dropdown.vue
+++ b/vue/components/ui/molecules/button-dropdown/button-dropdown.vue
@@ -30,6 +30,12 @@
     position: relative;
 }
 
+.button-dropdown.disabled {
+    cursor: default;
+    opacity: 0.4;
+    pointer-events: none;
+}
+
 .button-dropdown.button-dropdown-small {
     line-height: 30px;
 }
@@ -165,6 +171,10 @@ export const ButtonDropdown = {
             type: Array,
             default: null
         },
+        disabled: {
+            type: Boolean,
+            default: false
+        },
         dropdownVisible: {
             type: Boolean,
             default: false
@@ -178,7 +188,9 @@ export const ButtonDropdown = {
     },
     computed: {
         classes() {
-            const base = {};
+            const base = {
+                disabled: this.disabled
+            };
             base["button-dropdown-" + this.size] = true;
             return base;
         }
@@ -196,9 +208,11 @@ export const ButtonDropdown = {
             this.dropdownVisibleData = !this.dropdownVisibleData;
         },
         onSecondaryClick() {
+            if (this.disabled) return;
             this.toggleDropdown();
         },
         onPrimaryClick(event) {
+            if (this.disabled) return;
             this.$emit("click", event);
         },
         onDropdownItemClicked(event, item) {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Issue surged with https://github.com/ripe-tech/ripe-util-vue/issues/288 where the `button-dropdown` needed to be disabled|
| Decisions | Add `disabled` prop to `button-dropdown`|
| Animated GIF |![](http://g.recordit.co/EpjzUNYBrL.gif)|
