### PR TITLE
version: 0.23.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+*
+
+### Changed
+
+*
+
+### Fixed
+
+*
+
+## [0.23.1] - 2022-06-23
+
+### Added
+
 * Add `input-file` component - [ripe-copper/#48](https://github.com/ripe-tech/ripe-copper/issues/48)
 * Add slots to `input-symbol` component - [ripe-util-vue/#259](https://github.com/ripe-tech/ripe-util-vue/issues/259)
 * Button icon dropdown global hide prop - [ripe-pulse/#281](https://github.com/ripe-tech/ripe-pulse/issues/281)
 * Add `avatar-list` component - [#571](https://github.com/ripe-tech/ripe-components-vue/issues/571)
 * Added prop `debounceDelay` to component `input-symbol` - [#259](https://github.com/ripe-tech/ripe-util-vue/issues/259)
 * Add node `16`, `17` and `18` support
-
-### Changed
-
-*
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ripe-components-vue",
-    "version": "0.23.0",
+    "version": "0.23.1",
     "description": "RIPE Components for Vue.js",
     "keywords": [
         "components",


### PR DESCRIPTION
### Added

* Add `input-file` component - [ripe-copper/#48](https://github.com/ripe-tech/ripe-copper/issues/48)
* Add slots to `input-symbol` component - [ripe-util-vue/#259](https://github.com/ripe-tech/ripe-util-vue/issues/259)
* Button icon dropdown global hide prop - [ripe-pulse/#281](https://github.com/ripe-tech/ripe-pulse/issues/281)
* Add `avatar-list` component - [#571](https://github.com/ripe-tech/ripe-components-vue/issues/571)
* Added prop `debounceDelay` to component `input-symbol` - [#259](https://github.com/ripe-tech/ripe-util-vue/issues/259)
* Add node `16`, `17` and `18` support

### Fixed

* Fix spreadsheet icon's stroke width