### PR TITLE
feat: add `table-footer` slot to `table` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-*
+* Add `table-footer` slot to `table` component - [ripe-util-vue/#307](https://github.com/ripe-tech/ripe-util-vue/issues/307)
 
 ### Fixed
 

--- a/vue/components/ui/molecules/table/table.vue
+++ b/vue/components/ui/molecules/table/table.vue
@@ -75,6 +75,7 @@
                 <slot name="after-row" v-bind:item="item" v-bind:index="index" />
             </template>
         </transition-group>
+        <slot name="table-footer" v-bind:item="item" v-bind:index="index" />
     </table>
 </template>
 

--- a/vue/components/ui/molecules/table/table.vue
+++ b/vue/components/ui/molecules/table/table.vue
@@ -75,7 +75,7 @@
                 <slot name="after-row" v-bind:item="item" v-bind:index="index" />
             </template>
         </transition-group>
-        <slot name="table-footer" v-bind:item="item" v-bind:index="index" />
+        <slot name="table-footer" v-bind:item="item" />
     </table>
 </template>
 


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | [ripe-util-vue/#307](https://github.com/ripe-tech/ripe-util-vue/issues/307) |
| Decisions | Add a footer slot so the `pagination` component can be placed |
