### PR TITLE
fix: proper icon context paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-*
+* Fix Icon contexts path for Webpack 5 - [ripe-pulse/#348](https://github.com/ripe-tech/ripe-pulse/issues/348)
 
 ## [0.23.1] - 2022-06-23
 

--- a/vue/components/ui/atoms/icon/icon.vue
+++ b/vue/components/ui/atoms/icon/icon.vue
@@ -145,7 +145,7 @@ export const Icon = {
             try {
                 // tries to use the new webpack 5 strategy for the loading
                 // of the icon using the context strategy
-                return context(`./${icon}.${suffix}?raw`);
+                return context(`./${icon}.${suffix}`);
             } catch {
                 // defaults to webpack 4 asset bundling logic if v5
                 // retrieval resulted in an error, making it possible


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-pulse/issues/348 <br> `iconContexts` allow us to have a list of custom icons besides the default ikonate icons. We're using it in [some projects](https://github.com/search?q=org%3Aripe-tech+iconContexts&type=code) (all webpack 4). Currently there are no webpack5 projects implementing this and it looks like the implementation has always been broken. We never noticed until now that ripe-pulse (webpack 5) needs to implement this.   |
| Decisions | - Fix webpack 5 `iconContexts` sufix path. |
