### PR TITLE
version: 0.23.2 :rainbow: 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+*
+
+### Changed
+
+*
+
+### Fixed
+
+*
+
+## [0.23.2] - 2022-10-22
+
+### Added
+
 * Added `iconProps`, `uppercase` and `size` to `section-expandable`'s props - [ripe-util-vue/#288](https://github.com/ripe-tech/ripe-util-vue/issues/288)
 * Add `pagination` component - [ripe-util-vue/#307](https://github.com/ripe-tech/ripe-util-vue/issues/307)
 * Add `primaryColor` and `secondaryColor` prop to `dropdown-button` - [ripe-util-vue/#288](https://github.com/ripe-tech/ripe-util-vue/issues/288)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ripe-components-vue",
-    "version": "0.23.1",
+    "version": "0.23.2",
     "description": "RIPE Components for Vue.js",
     "keywords": [
         "components",


### PR DESCRIPTION
### Added

* Added `iconProps`, `uppercase` and `size` to `section-expandable`'s props - [ripe-util-vue/#288](https://github.com/ripe-tech/ripe-util-vue/issues/288)
* Add `pagination` component - [ripe-util-vue/#307](https://github.com/ripe-tech/ripe-util-vue/issues/307)
* Add `primaryColor` and `secondaryColor` prop to `dropdown-button` - [ripe-util-vue/#288](https://github.com/ripe-tech/ripe-util-vue/issues/288)

### Changed
* Add better loading style for other colors - [ripe-util-vue/#288](https://github.com/ripe-tech/ripe-util-vue/issues/288)
* Remove hover and interaction while loading - [ripe-util-vue/#288](https://github.com/ripe-tech/ripe-util-vue/issues/288)
* Add `table-footer` slot to `table` component - [ripe-util-vue/#307](https://github.com/ripe-tech/ripe-util-vue/issues/307)

### Fixed
* Fix Icon contexts path for Webpack 5 - [ripe-pulse/#348](https://github.com/ripe-tech/ripe-pulse/issues/348)
