### PR TITLE
#612 `upload-area` component not clearing data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-* `upload-area` component not clearing data - [#612](https://github.com/ripe-tech/ripe-util-vue/issues/612)
+* `upload-area` component not clearing data - [#612](https://github.com/ripe-tech/ripe-components-vue/issues/612)
 
 ## [0.23.2] - 2022-10-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-*
+* `upload-area` component not clearing data - [#612](https://github.com/ripe-tech/ripe-util-vue/issues/612)
 
 ## [0.23.2] - 2022-10-22
 

--- a/vue/components/ui/molecules/button-upload/button-upload.vue
+++ b/vue/components/ui/molecules/button-upload/button-upload.vue
@@ -87,15 +87,6 @@ export const ButtonUpload = {
             if (this.multiple) return "Upload Files";
             return "Upload File";
         }
-    },
-    watch: {
-        files(value) {
-            if (!value || value.length === 0) this.clear();
-            this.filesData = value;
-        },
-        dragging(value) {
-            this.$emit("update:dragging", value);
-        }
     }
 };
 export default ButtonUpload;

--- a/vue/mixins/upload.js
+++ b/vue/mixins/upload.js
@@ -25,6 +25,15 @@ export const uploadMixin = {
             fileInputRef: null
         };
     },
+    watch: {
+        files(value) {
+            if (!value || value.length === 0) this.clear();
+            this.filesData = value;
+        },
+        dragging(value) {
+            this.$emit("update:dragging", value);
+        }
+    },
     methods: {
         initUploadArea(filesInputRef) {
             this.fileInputRef = filesInputRef;


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-components-vue/issues/612 |
| Decisions | -Move common logic to the `upload` mixin |
| Animated GIF | ![T0yp5QhkP8](https://user-images.githubusercontent.com/8842023/198069412-7231c2ab-3076-4992-8d4a-6bcfc3b5d04b.gif) |
