### PR TITLE
feat: add reacticity to `emptySlots()` computed property in `molecules/upload-area.vue`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* Reacticity to `emptySlots()` computed propertie in `molecules/upload-area.vue` 
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* Reacticity to `emptySlots()` computed property in `molecules/upload-area.vue` 
+* Reactivity to `emptySlots()` computed property in `molecules/upload-area.vue` 
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* Reacticity to `emptySlots()` computed propertie in `molecules/upload-area.vue` 
+* Reacticity to `emptySlots()` computed property in `molecules/upload-area.vue` 
 
 ### Changed
 

--- a/vue/components/ui/molecules/input-file/input-file.vue
+++ b/vue/components/ui/molecules/input-file/input-file.vue
@@ -81,9 +81,6 @@ export const InputFile = {
             };
             return base;
         },
-        noFileSelected() {
-            return this.filesData.length === 0;
-        },
         buttonText() {
             return this.noFileSelected ? this.text : this.filesData[0].name;
         },

--- a/vue/components/ui/molecules/upload-area/upload-area.vue
+++ b/vue/components/ui/molecules/upload-area/upload-area.vue
@@ -150,13 +150,10 @@ export const UploadArea = {
             return this.draggingIcon ? this.draggingIcon : "cloud-upload";
         },
         emptySlots() {
-            // forces this property to refresh on data change
-            const bindRefresh = Boolean(this.filesData) || !this.filesData;
-
             return (
+                !this.noFileSelected &&
                 Object.entries(this.$slots).length === 0 &&
-                !this.$scopedSlots?.default &&
-                bindRefresh
+                !this.$scopedSlots?.default
             );
         }
     }

--- a/vue/components/ui/molecules/upload-area/upload-area.vue
+++ b/vue/components/ui/molecules/upload-area/upload-area.vue
@@ -150,7 +150,14 @@ export const UploadArea = {
             return this.draggingIcon ? this.draggingIcon : "cloud-upload";
         },
         emptySlots() {
-            return Object.entries(this.$slots).length === 0 && !this.$scopedSlots?.default;
+            // forces this property to refresh on data change
+            const bindRefresh = Boolean(this.filesData) || !this.filesData;
+
+            return (
+                Object.entries(this.$slots).length === 0 &&
+                !this.$scopedSlots?.default &&
+                bindRefresh
+            );
         }
     }
 };

--- a/vue/mixins/upload.js
+++ b/vue/mixins/upload.js
@@ -34,6 +34,11 @@ export const uploadMixin = {
             this.$emit("update:dragging", value);
         }
     },
+    computed: {
+        noFileSelected() {
+            return this.filesData?.length === 0;
+        }
+    },
     methods: {
         initUploadArea(filesInputRef) {
             this.fileInputRef = filesInputRef;


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | - |
| Dependencies | - |
| Decisions |Conceptually, `computed` values in `vue` are used when logic needs to be triggered when component internal `state` changes weather the logic is conditional to the state itself. In this specific case, `emptySlots()` is running only one time on component creation, limiting use-cases when the parent component adds or removes slots accordingly (see screenshots below) not removing the button when a slot is added. What was done to fix this:  <br> <br> - Reference the respective data property to react to, and use it in a way that doesn't alter the returning boolean expression  |
| Animated GIF | No slots: <img width="718" alt="Screenshot 2022-10-27 at 15 56 46" src="https://user-images.githubusercontent.com/8842023/198324835-a6138751-4be8-4c81-84e6-239b23170498.png"> With slots:<img width="702" alt="Screenshot 2022-10-27 at 15 57 12" src="https://user-images.githubusercontent.com/8842023/198325121-2c8fcc19-a707-440c-af22-0f4defbd7192.png"> |
