### PR TITLE
fix: fix test-utils version to 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * `upload-area` component not clearing data - [#612](https://github.com/ripe-tech/ripe-components-vue/issues/612)
+* Fix `@vue/test-utils` version to avoid breaking changes
 
 ## [0.23.2] - 2022-10-22
 

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
         "@storybook/manager-webpack5": "~6.4.22",
         "@storybook/source-loader": "~6.4.22",
         "@storybook/vue": "^6.4.18",
-        "@vue/test-utils": "^1.3.0",
+        "@vue/test-utils": "1.3.0",
         "babel-loader": "^8.2.3",
         "core-js": "^3.21.0",
         "cross-env": "^7.0.3",


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | - `@vue/test-utils` is throwing when building to run tests because of a breaking change after `1.3.0` version.  |
| Decisions | - Fix test-utils version to `1.3.0`  |
