### PR TITLE
#240 Filter orders - fix add filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-*
+* Fix `addFilter` for when the filter is empty - [ripe-pulse/#240](https://github.com/ripe-tech/ripe-pulse/issues/240)
+
 ## [0.23.5] - 2022-12-19
 
 ### Added

--- a/vue/components/ui/organisms/listing/listing.vue
+++ b/vue/components/ui/organisms/listing/listing.vue
@@ -424,18 +424,20 @@ export const Listing = {
         addFilter(key, value = undefined, replace = false, operator = "=") {
             const base = value === undefined ? `${key}` : `${key}${operator}`;
             const tuple = value === undefined ? `${key}` : `${key}${operator}${value}`;
+
+            let filters = this.filter ? this.filter.split(" and ") : [];
             if (this.filter && this.filter.search(base) !== -1) {
                 if (!replace) return;
-                const filters = this.filter
-                    .split(" and ")
-                    .filter(v => !v.includes(`${key}${operator}`));
-                this.filter = filters.join(" and ");
+                filters = filters.filter(v => !v.includes(`${key}${operator}`));
             }
-            this.filter += this.filter ? ` and ${tuple}` : tuple;
+            filters.push(tuple);
+            this.filter = filters.join(" and ");
+
             this.showScrollTop = true;
             this.scrollTop = true;
         },
         removeFilter(key, operator = "=") {
+            if (!this.filter) return;
             const filters = this.filter
                 .split(" and ")
                 .filter(v => !v.includes(`${key}${operator}`));


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-pulse/issues/240 |
| Decisions |The `addFilter` method wasn't dealing well with a previously `null` filter. Made some changes so it can function properly in all foreseen cases.|
