### PR TITLE
refactor: cleanup dead code var in slot

### DIFF
--- a/vue/components/ui/molecules/table/table.vue
+++ b/vue/components/ui/molecules/table/table.vue
@@ -75,7 +75,7 @@
                 <slot name="after-row" v-bind:item="item" v-bind:index="index" />
             </template>
         </transition-group>
-        <slot name="table-footer" v-bind:item="item" />
+        <slot name="table-footer" />
     </table>
 </template>
 


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Cleanup dead code variable `item` in slot that generates vue warns (only visible after linking ripe-pulse and ripe-components-vue for instance). Note that: in order to make a v-bind:var="var" inside a slot, this slot needs to be inside a template that receives this item. This was probably done by mistake from copy/paste of previous examples.
![image](https://user-images.githubusercontent.com/24736423/214871587-9f60cc4a-a61c-49a3-99cc-fa35a939cf06.png)|
| Decisions | - Cleanup dead code var that generates a spam of warnings |
