### PR TITLE
Only support Node.js LTS versions (14, 16, 18)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ jobs:
     name: Deploy
     strategy:
       matrix:
-        node-version: [12]
+        node-version: [18]
     runs-on: ubuntu-latest
     container: node:${{ matrix.node-version }}
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ jobs:
     name: Build
     strategy:
       matrix:
-        node-version: [12, 13, 14, 16, 17, 18]
+        node-version: [14, 16, 18]
     runs-on: ubuntu-latest
     container: node:${{ matrix.node-version }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Only support Node.js LTS versions (`14`, `16`, `18`)
-* Update `deploy.yml` node version to `18`
+* Update `deploy.yml` Node.js version to `18`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-*
+* Only support Node.js LTS versions (`14`, `16`, `18`)
+* Update `deploy.yml` node version to `18`
 
 ### Fixed
 


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | odd versions shouldn't be supported + node 12 should be deprecated as even node 14 will stop being supported at the end of this month |
| Dependencies | -- |
| Decisions | * Only support Node.js LTS versions (`14`, `16`, `18`) <br>* Update `deploy.yml` Node.js version to `18` |

